### PR TITLE
Add AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,5 @@
+David Baumgold <david@davidbaumgold.com>
+Sarina Canelake <sarina@edx.org>
+Ned Batchelder <ned@nedbatchelder.com>
+Will Daly <will@edx.org>
+Daniel Friedman <dfriedman@edx.org>


### PR DESCRIPTION
I (believe) I've followed the convention in the edx-platform AUTHORS file. Oldest committers up top, newest on the bottom.

@singingwolfboy @sarina 
