### PR TITLE
When PR is reopened, reopen the Jira ticket

### DIFF
--- a/openedx_webhooks/bot_comments.py
+++ b/openedx_webhooks/bot_comments.py
@@ -191,7 +191,6 @@ def github_end_survey_comment(pull_request: PrDict) -> str:
     """
     Create a "please fill out this survey" comment.
     """
-    print(pull_request)
     is_merged = pull_request.get("merged", False)
     url = SURVEY_URL.format(
         repo_full_name=pull_request["base"]["repo"]["full_name"],

--- a/openedx_webhooks/github_views.py
+++ b/openedx_webhooks/github_views.py
@@ -85,6 +85,7 @@ def hook_receiver():
     pr = event["pull_request"]
     pr_number = pr["number"]
     action = event["action"]
+    pr["hook_action"] = event["action"]
 
     pr_activity = f"{repo} #{pr_number} {action!r}"
     if action in ["opened", "edited", "closed", "synchronize", "ready_for_review", "converted_to_draft"]:

--- a/openedx_webhooks/tasks/pr_tracking.py
+++ b/openedx_webhooks/tasks/pr_tracking.py
@@ -234,7 +234,9 @@ def desired_support_state(pr: PrDict) -> Optional[PrDesiredInfo]:
     else:
         desired.is_ospr = True
 
-    if pr["state"] == "open":
+    if pr.get("hook_action") == "reopened":
+        state = "reopened"
+    elif pr["state"] == "open":
         state = "open"
     elif pr["merged"]:
         state = "merged"
@@ -259,7 +261,7 @@ def desired_support_state(pr: PrDict) -> Optional[PrDesiredInfo]:
             if map_1_2 is not None:
                 desired.jira_extra_fields["Platform Map Area (Levels 1 & 2)"] = map_1_2
     elif desired.is_ospr:
-        if state == "open":
+        if state in ["open", "reopened"]:
             comment = BotComment.WELCOME
         else:
             comment = BotComment.WELCOME_CLOSED
@@ -300,6 +302,8 @@ def desired_support_state(pr: PrDict) -> Optional[PrDesiredInfo]:
             desired.jira_status = "Rejected"
         elif state == "merged":
             desired.jira_status = "Merged"
+        elif state == "reopened":
+            desired.jira_status = "Community Manager Review"
 
         if state in ["closed", "merged"]:
             desired.bot_comments.add(BotComment.SURVEY)

--- a/tests/fake_github.py
+++ b/tests/fake_github.py
@@ -162,6 +162,14 @@ class PullRequest:
         self.merged = merge
         self.closed_at = datetime.datetime.now()
 
+    def reopen(self):
+        """
+        Re-open a pull request.
+        """
+        self.state = "open"
+        self.merged = False
+        self.closed_at = None
+
     def add_comment(self, user="someone", **kwargs) -> Comment:
         comment = self.repo.make_comment(user, **kwargs)
         self.comments.append(comment.id)


### PR DESCRIPTION
on action `reopened` we want to reopen the PR

my thought it should be reopened in Needs Triage, this accounts for users reopening on their own and we will need to look at them again