### PR TITLE
test: add a failing test of reopen behavior

### DIFF
--- a/openedx_webhooks/bot_comments.py
+++ b/openedx_webhooks/bot_comments.py
@@ -215,7 +215,6 @@ def github_end_survey_comment(pull_request: PrDict) -> str:
     """
     Create a "please fill out this survey" comment.
     """
-    print(pull_request)
     is_merged = pull_request.get("merged", False)
     url = SURVEY_URL.format(
         repo_full_name=pull_request["base"]["repo"]["full_name"],

--- a/tests/fake_github.py
+++ b/tests/fake_github.py
@@ -162,6 +162,14 @@ class PullRequest:
         self.merged = merge
         self.closed_at = datetime.datetime.now()
 
+    def reopen(self):
+        """
+        Re-open a pull request.
+        """
+        self.state = "open"
+        self.merged = False
+        self.closed_at = None
+
     def add_comment(self, user="someone", **kwargs) -> Comment:
         comment = self.repo.make_comment(user, **kwargs)
         self.comments.append(comment.id)

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -24,14 +24,29 @@ def sync_labels_fn(mocker):
     return mocker.patch("openedx_webhooks.tasks.github_work.synchronize_labels")
 
 
+def close_and_reopen_pr(reqctx, pr):
+    """For testing re-opening, close the pr, process it, then re-open it."""
+    pr.close(merge=False)
+    with reqctx:
+        pull_request_changed(pr.as_json())
+    pr.reopen()
+    with reqctx:
+        return pull_request_changed(pr.as_json())
+
+
 def test_internal_pr_opened(reqctx, fake_github):
     pr = fake_github.make_pull_request(user="nedbat")
     with reqctx:
         key, anything_happened = pull_request_changed(pr.as_json())
+
     assert key is None
     assert anything_happened is False
     assert len(pr.list_comments()) == 0
     assert pr.status(CLA_CONTEXT) is None
+
+    key, anything_happened2 = close_and_reopen_pr(reqctx, pr)
+    assert key is None
+    assert anything_happened2 is False
 
 
 def test_pr_in_private_repo_opened(reqctx, fake_github, fake_jira):
@@ -106,6 +121,16 @@ def test_external_pr_opened_no_cla(reqctx, sync_labels_fn, fake_github, fake_jir
     }
     # Check the status check applied to the latest commit.
     assert pr.status(CLA_CONTEXT) == "failure"
+
+    # Test re-opening.
+    issue_id2, anything_happened2 = close_and_reopen_pr(reqctx, pr)
+    assert issue_id2 == issue_id
+    assert anything_happened2 is False
+    # Now there are two comments, closing the PR added a survey comment.
+    assert len(pr.list_comments()) == 2
+
+    issue = fake_jira.issues[issue_id]
+    assert issue.status == "Community Manager Review"   # This fails: Jira is still Rejected.
 
 
 def test_external_pr_opened_with_cla(reqctx, sync_labels_fn, fake_github, fake_jira):
@@ -833,7 +858,6 @@ def test_extra_fields_are_ok(reqctx, fake_github, fake_jira):
 
     # PR gets rescanned.
     with reqctx:
-        print("GOING AGAIN")
         issue_id2, happened = pull_request_changed(pr.as_json())
 
     assert not happened


### PR DESCRIPTION
@sarina Here's an approach to testing re-opening.

This points out two things:

First, the test fails because after closing and re-opening, the Jira ticket is still "Rejected."  I haven't looked into why that is.

Second, closing the PR adds a bot comment to take the survey.  Do we want to do anything about that? We could remove that comment, or we could add another "yay, re-opened!" comment, or something else.