### PR TITLE
temp: map the action to a new key in the pr json, for reopening

### DIFF
--- a/openedx_webhooks/github_views.py
+++ b/openedx_webhooks/github_views.py
@@ -85,8 +85,7 @@ def hook_receiver():
     pr = event["pull_request"]
     pr_number = pr["number"]
     action = event["action"]
-    if action == "reopened":
-        pr["state"] = "reopened"
+    pr["hook_action"] = event["action"]
 
     pr_activity = f"{repo} #{pr_number} {action!r}"
     if action in ["opened", "edited", "closed", "synchronize", "ready_for_review", "converted_to_draft", "reopened"]:

--- a/openedx_webhooks/tasks/pr_tracking.py
+++ b/openedx_webhooks/tasks/pr_tracking.py
@@ -234,10 +234,10 @@ def desired_support_state(pr: PrDict) -> Optional[PrDesiredInfo]:
     else:
         desired.is_ospr = True
 
-    if pr["state"] == "open":
-        state = "open"
-    elif pr["state"] == "reopened":
+    if pr.get("hook_action") == "reopened":
         state = "reopened"
+    elif pr["state"] == "open":
+        state = "open"
     elif pr["merged"]:
         state = "merged"
     else:

--- a/tests/fake_github.py
+++ b/tests/fake_github.py
@@ -169,7 +169,6 @@ class PullRequest:
         self.state = "open"
         self.merged = False
         self.closed_at = None
-        # Need to be able to define `self.event.action = "reopened"` here
 
     def add_comment(self, user="someone", **kwargs) -> Comment:
         comment = self.repo.make_comment(user, **kwargs)

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -37,7 +37,9 @@ def close_and_reopen_pr(reqctx, pr):
         pull_request_changed(pr.as_json())
     pr.reopen()
     with reqctx:
-        return pull_request_changed(pr.as_json())
+        prj = pr.as_json()
+        prj["hook_action"] = "reopened"
+        return pull_request_changed(prj)
 
 
 def test_internal_pr_opened(reqctx, fake_github, fake_jira):
@@ -137,7 +139,7 @@ def test_external_pr_opened_no_cla(reqctx, sync_labels_fn, fake_github, fake_jir
     assert len(pr.list_comments()) == 2
 
     issue = fake_jira.issues[issue_id]
-    assert issue.status == "Community Manager Review"   # This fails: Jira is still Rejected.
+    assert issue.status == "Community Manager Review"
 
 
 def test_external_pr_opened_with_cla(reqctx, sync_labels_fn, fake_github, fake_jira):
@@ -183,8 +185,19 @@ def test_external_pr_opened_with_cla(reqctx, sync_labels_fn, fake_github, fake_j
 
     # Check the GitHub labels that got applied.
     assert pr.labels == {"needs triage", "open-source-contribution"}
+
     # Check the status check applied to the latest commit.
     assert pr.status(CLA_CONTEXT) == CLA_STATUS_GOOD
+
+    # Test re-opening.
+    issue_id2, anything_happened2 = close_and_reopen_pr(reqctx, pr)
+    assert issue_id2 == issue_id
+    assert anything_happened2 is True
+    # Now there are two comments, closing the PR added a survey comment.
+    assert len(pr.list_comments()) == 2
+
+    issue = fake_jira.issues[issue_id]
+    assert issue.status == "Community Manager Review"
 
 
 def test_core_committer_pr_opened(reqctx, sync_labels_fn, fake_github, fake_jira):


### PR DESCRIPTION
This makes the tests pass.  Since the "reopen" fact isn't in the pull request, but instead in the hook action, I added it to the pr data as a separate piece of information.

It's not great that the hook handler isn't tested by the test suite, and we have to add a line to the tests to parallel a line in the handler, but I think this will work.

@natabene is this the behavior you want?: When a pull request is reopened, the Jira status becomes "Community Manager Review", regardless of other considerations.