### PR TITLE
Complete the re-open work

### DIFF
--- a/changelog.d/20220324_222015_nedbat_better_reopen.rst
+++ b/changelog.d/20220324_222015_nedbat_better_reopen.rst
@@ -1,0 +1,5 @@
+.. A new scriv changelog fragment.
+
+- Pull requests can now be closed and re-opened.  When the pull request is
+  re-opened, the survey comment that was added on closing is deleted.  The Jira
+  ticket is returned to the state it was in before the pull request was closed.

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -146,3 +146,11 @@ request.
 
 If the pull request was a core committer PR, the bot leaves a comment pinging
 the committer's edX champions, to help them stay current.
+
+
+When a pull request is re-opened
+--------------------------------
+
+The bot deletes the "please complete a survey" comment that was added when the
+pull request was closed.  The Jira issue is returned to the state it was in
+when the pull request was closed.

--- a/openedx_webhooks/bot_comments.py
+++ b/openedx_webhooks/bot_comments.py
@@ -191,7 +191,6 @@ def github_end_survey_comment(pull_request: PrDict) -> str:
     """
     Create a "please fill out this survey" comment.
     """
-    print(pull_request)
     is_merged = pull_request.get("merged", False)
     url = SURVEY_URL.format(
         repo_full_name=pull_request["base"]["repo"]["full_name"],

--- a/openedx_webhooks/github_views.py
+++ b/openedx_webhooks/github_views.py
@@ -85,9 +85,10 @@ def hook_receiver():
     pr = event["pull_request"]
     pr_number = pr["number"]
     action = event["action"]
+    pr["hook_action"] = event["action"]
 
     pr_activity = f"{repo} #{pr_number} {action!r}"
-    if action in ["opened", "edited", "closed", "synchronize", "ready_for_review", "converted_to_draft"]:
+    if action in ["opened", "edited", "closed", "synchronize", "ready_for_review", "converted_to_draft", "reopened"]:
         logger.info(f"{pr_activity}, processing...")
         result = pull_request_changed_task.delay(pr, wsgi_environ=minimal_wsgi_environ())
     else:

--- a/openedx_webhooks/tasks/pr_tracking.py
+++ b/openedx_webhooks/tasks/pr_tracking.py
@@ -234,7 +234,9 @@ def desired_support_state(pr: PrDict) -> Optional[PrDesiredInfo]:
     else:
         desired.is_ospr = True
 
-    if pr["state"] == "open":
+    if pr.get("hook_action") == "reopened":
+        state = "reopened"
+    elif pr["state"] == "open":
         state = "open"
     elif pr["merged"]:
         state = "merged"
@@ -259,7 +261,7 @@ def desired_support_state(pr: PrDict) -> Optional[PrDesiredInfo]:
             if map_1_2 is not None:
                 desired.jira_extra_fields["Platform Map Area (Levels 1 & 2)"] = map_1_2
     elif desired.is_ospr:
-        if state == "open":
+        if state in ["open", "reopened"]:
             comment = BotComment.WELCOME
         else:
             comment = BotComment.WELCOME_CLOSED
@@ -300,6 +302,8 @@ def desired_support_state(pr: PrDict) -> Optional[PrDesiredInfo]:
             desired.jira_status = "Rejected"
         elif state == "merged":
             desired.jira_status = "Merged"
+        elif state == "reopened":
+            desired.jira_status = "Community Manager Review"
 
         if state in ["closed", "merged"]:
             desired.bot_comments.add(BotComment.SURVEY)

--- a/tests/fake_github.py
+++ b/tests/fake_github.py
@@ -393,14 +393,14 @@ class FakeGitHub(faker.Faker):
     # Commmits
 
     @faker.route(r"/repos/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pulls/(?P<number>\d+)/commits(\?.*)?")
-    def _get_pr_commits(self, match, request, _context) -> List[Dict[str, str]]:
+    def _get_pr_commits(self, match, _request, _context) -> List[Dict[str, str]]:
         r = self.get_repo(match["owner"], match["repo"])
         pr = r.get_pull_request(int(match["number"]))
         data = [{'sha': sha} for sha in pr.commits]
         return data
 
     @faker.route(r"/repos/(?P<owner>[^/]+)/(?P<repo>[^/]+)/statuses/(?P<sha>[a-fA-F0-9]+)(\?.*)?")
-    def _get_pr_status_check(self, match, request, _context) -> List[Dict[str, Any]]:
+    def _get_pr_status_check(self, match, _request, _context) -> List[Dict[str, Any]]:
         sha: str = match["sha"]
         if sha in self.cla_statuses:
             return [self.cla_statuses[sha]]

--- a/tests/fake_github.py
+++ b/tests/fake_github.py
@@ -162,6 +162,14 @@ class PullRequest:
         self.merged = merge
         self.closed_at = datetime.datetime.now()
 
+    def reopen(self):
+        """
+        Re-open a pull request.
+        """
+        self.state = "open"
+        self.merged = False
+        self.closed_at = None
+
     def add_comment(self, user="someone", **kwargs) -> Comment:
         comment = self.repo.make_comment(user, **kwargs)
         self.comments.append(comment.id)

--- a/tests/test_rescan.py
+++ b/tests/test_rescan.py
@@ -229,7 +229,7 @@ def test_rescan_organization(rescannable_org, reqctx, pull_request_changed_fn, a
 def test_rescan_failure(mocker, rescannable_repo, reqctx):
     def flaky_pull_request_changed(pr, actions):
         if pr["number"] == 108:
-            1/0 # BOOM
+            return 1/0 # BOOM
         else:
             return pull_request_changed(pr, actions)
 


### PR DESCRIPTION
@sarina @natabene 

This is the full implementation of re-opening.  On re-opening, the bot deletes the "survey" comment that had been added, and the Jira ticket is returned to the state it was in when the pull request was closed.