### PR TITLE
feat: Point the openedx_webhooks bot to the new data repo.

### DIFF
--- a/openedx_webhooks/info.py
+++ b/openedx_webhooks/info.py
@@ -38,7 +38,7 @@ def _read_repotools_file(filename):
     Read the text of a repo-tools-data file.
     """
     github = get_github_session()
-    resp = github.get(f"https://raw.githubusercontent.com/edx/repo-tools-data/master/{filename}")
+    resp = github.get(f"https://raw.githubusercontent.com/openedx/openedx-webhooks-data/master/{filename}")
     resp.raise_for_status()
     return resp.text
 

--- a/openedx_webhooks/info.py
+++ b/openedx_webhooks/info.py
@@ -19,6 +19,8 @@ from openedx_webhooks.utils import (
     retry_get,
 )
 
+DATA_FILES_URL_BASE = "https://raw.githubusercontent.com/openedx/openedx-webhooks-data/master/"
+
 
 @memoize_timed(minutes=15)
 def _read_repotools_yaml_file(filename):
@@ -38,7 +40,7 @@ def _read_repotools_file(filename):
     Read the text of a repo-tools-data file.
     """
     github = get_github_session()
-    resp = github.get(f"https://raw.githubusercontent.com/openedx/openedx-webhooks-data/master/{filename}")
+    resp = github.get(f"{DATA_FILES_URL_BASE}{filename}")
     resp.raise_for_status()
     return resp.text
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def fake_repo_data(requests_mocker):
             return data.read()
 
     requests_mocker.get(
-        re.compile(f"https://raw.githubusercontent.com/edx/repo-tools-data/master/"),
+        re.compile(f"{openedx_webhooks.info.DATA_FILES_URL_BASE}"),
         text=_repo_data_callback,
     )
 


### PR DESCRIPTION
As a part of the transition from edX to tCRIL, the repo-tools-data repo did
not get transferred.  A copy of the data needed by this application was made
and put into the openedx-webhooks-data repo in the openedx org.

This change points the app to load data from that repo instead.  Operationally,
that repo has the credentials for the edx-webhooks GitHub user and so that user
has also been given access to the new openedx-webhooks-data repo.
