### PR TITLE
fix: re-label to any jira status

### DIFF
--- a/changelog.d/20220406_145815_nedbat_read_all_labels.rst
+++ b/changelog.d/20220406_145815_nedbat_read_all_labels.rst
@@ -1,0 +1,5 @@
+.. A new scriv changelog fragment.
+
+- Repos with more than 30 labels might not have properly labelled pull requests
+  that transitioned into late-alphabet statuses (like Open edX Community
+  Review).  This is now fixed.

--- a/openedx_webhooks/tasks/pr_tracking.py
+++ b/openedx_webhooks/tasks/pr_tracking.py
@@ -93,7 +93,7 @@ class PrCurrentInfo:
     bot_comment0_text: Optional[str] = None
 
     # The comment id of the survey comment, if any.
-    bot_survey_comment_id: Options[str] = None
+    bot_survey_comment_id: Optional[str] = None
 
     # The last-seen state stored in the first bot comment.
     last_seen_state: Dict = field(default_factory=dict)

--- a/tests/fake_github.py
+++ b/tests/fake_github.py
@@ -423,7 +423,7 @@ class FakeGitHub(faker.Faker):
         return [label.as_json() for label in r.labels.values()]
 
     @faker.route(r"/repos/(?P<owner>[^/]+)/(?P<repo>[^/]+)/labels", "POST")
-    def _post_labels(self, match, request, context):
+    def _post_labels(self, match, request, context) -> Dict:
         # https://developer.github.com/v3/issues/labels/#create-a-label
         r = self.get_repo(match["owner"], match["repo"])
         label = r.add_label(**request.json())
@@ -431,7 +431,7 @@ class FakeGitHub(faker.Faker):
         return label.as_json()
 
     @faker.route(r"/repos/(?P<owner>[^/]+)/(?P<repo>[^/]+)/labels/(?P<name>.*)", "PATCH")
-    def _patch_labels(self, match, request, _context):
+    def _patch_labels(self, match, request, _context) -> Dict:
         # https://developer.github.com/v3/issues/labels/#update-a-label
         r = self.get_repo(match["owner"], match["repo"])
         data = request.json()
@@ -441,7 +441,7 @@ class FakeGitHub(faker.Faker):
         return label.as_json()
 
     @faker.route(r"/repos/(?P<owner>[^/]+)/(?P<repo>[^/]+)/labels/(?P<name>.*)", "DELETE")
-    def _delete_labels(self, match, _request, context):
+    def _delete_labels(self, match, _request, context) -> None:
         # https://developer.github.com/v3/issues/labels/#delete-a-label
         r = self.get_repo(match["owner"], match["repo"])
         r.delete_label(unquote(match["name"]))
@@ -474,7 +474,7 @@ class FakeGitHub(faker.Faker):
         return comment.as_json()
 
     @faker.route(r"/repos/(?P<owner>[^/]+)/(?P<repo>[^/]+)/issues/comments/(?P<comment_id>\d+)", "DELETE")
-    def _delete_issues_comments(self, match, _request, context) -> Dict:
+    def _delete_issues_comments(self, match, _request, context) -> None:
         # https://developer.github.com/v3/issues/comments/#delete-an-issue-comment
         r = self.get_repo(match["owner"], match["repo"])
         del r.comments[int(match["comment_id"])]


### PR DESCRIPTION
We weren't paginating the labels, so we only got 30.  In edx-platform,
"open edx community review" was the 31st label, so we thought it didn't
exist, so we wouldn't add the label when a Jira ticket was transitioned
to Open edX Community Review.