### PR TITLE
feat: Jira might be turned off, or change over time

### DIFF
--- a/changelog.d/20220609_151524_nedbat_no_jira.rst
+++ b/changelog.d/20220609_151524_nedbat_no_jira.rst
@@ -1,0 +1,4 @@
+.. A new scriv changelog fragment.
+
+- Removing the JIRA_SERVER setting will disable Jira access for the bot. No Jira
+  issues will be created or updated.

--- a/openedx_webhooks/bot_comments.py
+++ b/openedx_webhooks/bot_comments.py
@@ -105,7 +105,7 @@ def github_community_pr_comment(pull_request: PrDict, issue_key: str, **kwargs) 
         has_signed_agreement=pull_request_has_cla(pull_request),
         is_draft=is_draft_pull_request(pull_request),
         is_merged=pull_request.get("merged", False),
-        jira_host=settings.JIRA_SERVER,
+        jira_server=settings.JIRA_SERVER,
         **kwargs
     )
 
@@ -119,7 +119,7 @@ def github_community_pr_comment_closed(pull_request: PrDict, issue_key: str, **k
         "github_community_pr_comment_closed.md.j2",
         issue_key=issue_key,
         is_merged=pull_request.get("merged", False),
-        jira_host=settings.JIRA_SERVER,
+        jira_server=settings.JIRA_SERVER,
         **kwargs
     )
 
@@ -133,7 +133,7 @@ def github_committer_pr_comment(pull_request: PrDict, issue_key: str, **kwargs) 
         user=pull_request["user"]["login"],
         issue_key=issue_key,
         is_draft=is_draft_pull_request(pull_request),
-        jira_host=settings.JIRA_SERVER,
+        jira_server=settings.JIRA_SERVER,
         **kwargs
     )
 
@@ -172,7 +172,7 @@ def github_blended_pr_comment(
         project_name=project_name,
         project_page=project_page,
         is_draft=is_draft_pull_request(pull_request),
-        jira_host=settings.JIRA_SERVER,
+        jira_server=settings.JIRA_SERVER,
         **kwargs
     )
 

--- a/openedx_webhooks/info.py
+++ b/openedx_webhooks/info.py
@@ -10,6 +10,7 @@ from typing import Dict, Iterable, Optional, Union
 import yaml
 from iso8601 import parse_date
 
+from openedx_webhooks import settings
 from openedx_webhooks.lib.github.models import PrId
 from openedx_webhooks.oauth import get_github_session
 from openedx_webhooks.types import PrDict, PrCommentDict
@@ -307,6 +308,8 @@ def jira_project_for_ospr(pr: PrDict) -> Optional[str]:
 
     Returns a string or None if no Jira should be used.
     """
+    if settings.JIRA_SERVER is None:
+        return None
     return "OSPR"
 
 
@@ -316,4 +319,6 @@ def jira_project_for_blended(pr: PrDict) -> Optional[str]:
 
     Returns a string or None if no Jira should be used.
     """
+    if settings.JIRA_SERVER is None:
+        return None
     return "BLENDED"

--- a/openedx_webhooks/info.py
+++ b/openedx_webhooks/info.py
@@ -299,3 +299,21 @@ def get_jira_issue_key(pr: Union[PrId, PrDict]) -> Optional[str]:
         if match:
             return match.group(0)
     return None
+
+
+def jira_project_for_ospr(pr: PrDict) -> Optional[str]:
+    """
+    What Jira project should be used for this external pull request?
+
+    Returns a string or None if no Jira should be used.
+    """
+    return "OSPR"
+
+
+def jira_project_for_blended(pr: PrDict) -> Optional[str]:
+    """
+    What Jira project should be used for this blended pull request?
+
+    Returns a string or None if no Jira should be used.
+    """
+    return "BLENDED"

--- a/openedx_webhooks/settings.py
+++ b/openedx_webhooks/settings.py
@@ -6,7 +6,7 @@ from typing import Optional
 from openedx_webhooks.types import GhProject
 
 
-JIRA_SERVER = os.environ.get("JIRA_SERVER", "https://none.nojira.net")
+JIRA_SERVER = os.environ.get("JIRA_SERVER", None)
 
 def read_project_setting(setting_name: str) -> Optional[GhProject]:
     """Read a project spec from a setting.

--- a/openedx_webhooks/settings.py
+++ b/openedx_webhooks/settings.py
@@ -6,7 +6,9 @@ from typing import Optional
 from openedx_webhooks.types import GhProject
 
 
-JIRA_SERVER = os.environ.get("JIRA_SERVER", None)
+# The Jira server to use.  Missing or "" will become None,
+# meaning don't use Jira at all.
+JIRA_SERVER = os.environ.get("JIRA_SERVER", None) or None
 
 def read_project_setting(setting_name: str) -> Optional[GhProject]:
     """Read a project spec from a setting.

--- a/openedx_webhooks/templates/github_blended_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_blended_pr_comment.md.j2
@@ -1,7 +1,9 @@
 {% filter replace("\n", " ")|trim %}
 Thanks for the pull request, @{{ user }}!
-I've created [{{ issue_key }}]({{ jira_host }}/browse/{{ issue_key }})
+{% if issue_key %}
+I've created [{{ issue_key }}]({{ jira_server }}/browse/{{ issue_key }})
 to keep track of it in Jira.
+{% endif %}
 {% if deleted_issue_key %}
 (The original issue {{ deleted_issue_key }} has been deleted.)
 {% endif %}

--- a/openedx_webhooks/templates/github_committer_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_committer_pr_comment.md.j2
@@ -1,7 +1,9 @@
 {% filter replace("\n", " ")|trim %}
-Thanks for the pull request, @{{ user }}! I've created
-[{{ issue_key }}]({{ jira_host }}/browse/{{ issue_key }})
+Thanks for the pull request, @{{ user }}!
+{% if issue_key %}
+I've created [{{ issue_key }}]({{ jira_server }}/browse/{{ issue_key }})
 to keep track of it in JIRA.
+{% endif %}
 {% endfilter %}
 
 {% filter replace("\n", " ")|trim %}

--- a/openedx_webhooks/templates/github_community_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment.md.j2
@@ -1,7 +1,9 @@
 {% filter replace("\n", " ")|trim %}
-Thanks for the pull request, @{{ user }}! I've created
-[{{ issue_key }}]({{ jira_host }}/browse/{{ issue_key }})
+Thanks for the pull request, @{{ user }}!
+{% if issue_key %}
+I've created [{{ issue_key }}]({{ jira_server }}/browse/{{ issue_key }})
 to keep track of it in JIRA, where we prioritize reviews.
+{% endif %}
 Please note that it may take us up to several weeks or months to complete a review and merge your PR.
 {% endfilter %}
 

--- a/openedx_webhooks/templates/github_community_pr_comment_closed.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment_closed.md.j2
@@ -1,9 +1,13 @@
 {% filter replace("\n", " ")|trim %}
 Although this pull request is already
 {% if is_merged %}merged{% else %}closed{% endif %},
+{% if issue_key %}
 I've created
-[{{ issue_key }}]({{ jira_host }}/browse/{{ issue_key }})
+[{{ issue_key }}]({{ jira_server }}/browse/{{ issue_key }})
 so that we can track it in Jira.
+{% else %}
+I'm still watching it for updates.
+{% endif %}
 {% endfilter %}
 
 {% filter replace("\n", " ")|trim %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,3 +144,13 @@ def reset_all_memoized_functions():
 def is_merged(request):
     """Makes tests try both merged and closed pull requests."""
     return request.param
+
+
+@pytest.fixture(params=[
+    pytest.param(False, id="jira:no"),
+    pytest.param(True, id="jira:yes"),
+])
+def has_jira(request, mocker):
+    """Makes tests try both with and without accessing Jira."""
+    mocker.patch("openedx_webhooks.settings.JIRA_SERVER", TEST_JIRA if request.param else None)
+    return request.param

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -1,6 +1,5 @@
 """Tests of tasks/github.py:pull_request_changed for opening pull requests."""
 
-import itertools
 from datetime import datetime
 
 import pytest
@@ -19,6 +18,8 @@ from openedx_webhooks.github.dispatcher.actions.utils import (
 )
 from openedx_webhooks.info import get_jira_issue_key
 from openedx_webhooks.tasks.github import pull_request_changed
+
+from .helpers import check_issue_link_in_markdown
 
 # These tests should run when we want to test flaky GitHub behavior.
 pytestmark = pytest.mark.flaky_github
@@ -86,7 +87,7 @@ def test_pr_opened_by_bot(reqctx, fake_github, fake_jira):
     assert not pr.is_in_project(settings.GITHUB_BLENDED_PROJECT)
 
 
-def test_external_pr_opened_no_cla(reqctx, sync_labels_fn, fake_github, fake_jira):
+def test_external_pr_opened_no_cla(has_jira, reqctx, sync_labels_fn, fake_github, fake_jira):
     # No CLA, because this person is not in people.yaml
     fake_github.make_user(login="new_contributor", name="Newb Contributor")
     pr = fake_github.make_pull_request(owner="edx", repo="edx-platform", user="new_contributor")
@@ -95,45 +96,49 @@ def test_external_pr_opened_no_cla(reqctx, sync_labels_fn, fake_github, fake_jir
     with reqctx:
         issue_id, anything_happened = pull_request_changed(prj)
 
-    assert issue_id is not None
-    assert issue_id.startswith("OSPR-")
     assert anything_happened is True
 
-    # Check the Jira issue that was created.
-    assert len(fake_jira.issues) == 1
-    issue = fake_jira.issues[issue_id]
-    assert issue.contributor_name == "Newb Contributor"
-    assert issue.customer is None
-    assert issue.pr_number == prj["number"]
-    assert issue.repo == prj["base"]["repo"]["full_name"]
-    assert issue.url == prj["html_url"]
-    assert issue.description == prj["body"]
-    assert issue.issuetype == "Pull Request Review"
-    assert issue.summary == prj["title"]
-    assert issue.labels == set()
+    if has_jira:
+        assert issue_id.startswith("OSPR-")
 
-    # Check that the Jira issue was moved to Community Manager Review.
-    assert issue.status == "Community Manager Review"
+        # Check the Jira issue that was created.
+        assert len(fake_jira.issues) == 1
+        issue = fake_jira.issues[issue_id]
+        assert issue.contributor_name == "Newb Contributor"
+        assert issue.customer is None
+        assert issue.pr_number == prj["number"]
+        assert issue.repo == prj["base"]["repo"]["full_name"]
+        assert issue.url == prj["html_url"]
+        assert issue.description == prj["body"]
+        assert issue.issuetype == "Pull Request Review"
+        assert issue.summary == prj["title"]
+        assert issue.labels == set()
+
+        # Check that the Jira issue was moved to Community Manager Review.
+        assert issue.status == "Community Manager Review"
+    else:
+        assert issue_id is None
+        assert len(fake_jira.issues) == 0
 
     # Check that we synchronized labels.
-    sync_labels_fn.assert_called_once_with("edx/edx-platform")
+    sync_labels_fn.assert_called_once_with(f"edx/edx-platform")
 
     # Check the GitHub comment that was created.
     pr_comments = pr.list_comments()
     assert len(pr_comments) == 1
     body = pr_comments[0].body
-    jira_link = "[{id}](https://test.atlassian.net/browse/{id})".format(id=issue_id)
-    assert jira_link in body
+    check_issue_link_in_markdown(body, issue_id)
     assert "Thanks for the pull request, @new_contributor!" in body
     assert is_comment_kind(BotComment.NEED_CLA, body)
     assert is_comment_kind(BotComment.WELCOME, body)
     assert not is_comment_kind(BotComment.OK_TO_TEST, body)
 
     # Check the GitHub labels that got applied.
-    assert pr.labels == {
-        'community manager review',
-        'open-source-contribution',
-    }
+    expected_labels = {"open-source-contribution"}
+    if has_jira:
+        expected_labels.add("community manager review")
+    assert pr.labels == expected_labels
+
     # Check the status check applied to the latest commit.
     assert pr.status(CLA_CONTEXT) == CLA_STATUS_BAD
     # It should have been put in the OSPR project.
@@ -148,53 +153,62 @@ def test_external_pr_opened_no_cla(reqctx, sync_labels_fn, fake_github, fake_jir
     # re-opening it deleted it.
     assert len(pr.list_comments()) == 1
 
-    issue = fake_jira.issues[issue_id]
-    assert issue.status == "Community Manager Review"
+    if has_jira:
+        issue = fake_jira.issues[issue_id]
+        assert issue.status == "Community Manager Review"
+    else:
+        assert len(fake_jira.issues) == 0
 
 
-def test_external_pr_opened_with_cla(reqctx, sync_labels_fn, fake_github, fake_jira):
+def test_external_pr_opened_with_cla(has_jira, reqctx, sync_labels_fn, fake_github, fake_jira):
     pr = fake_github.make_pull_request(owner="edx", repo="some-code", user="tusbar", number=11235)
     prj = pr.as_json()
 
     with reqctx:
         issue_id, anything_happened = pull_request_changed(prj)
 
-    assert issue_id is not None
-    assert issue_id.startswith("OSPR-")
     assert anything_happened is True
+    if has_jira:
+        assert issue_id is not None
+        assert issue_id.startswith("OSPR-")
 
-    # Check the Jira issue that was created.
-    assert len(fake_jira.issues) == 1
-    issue = fake_jira.issues[issue_id]
-    assert issue.contributor_name == "Bertrand Marron"
-    assert issue.customer == ["IONISx"]
-    assert issue.pr_number == 11235
-    assert issue.repo == "edx/some-code"
-    assert issue.url == prj["html_url"]
-    assert issue.description == prj["body"]
-    assert issue.issuetype == "Pull Request Review"
-    assert issue.summary == prj["title"]
-    assert issue.labels == set()
+        # Check the Jira issue that was created.
+        assert len(fake_jira.issues) == 1
+        issue = fake_jira.issues[issue_id]
+        assert issue.contributor_name == "Bertrand Marron"
+        assert issue.customer == ["IONISx"]
+        assert issue.pr_number == 11235
+        assert issue.repo == f"edx/some-code"
+        assert issue.url == prj["html_url"]
+        assert issue.description == prj["body"]
+        assert issue.issuetype == "Pull Request Review"
+        assert issue.summary == prj["title"]
+        assert issue.labels == set()
 
-    # Check that the Jira issue is in Needs Triage.
-    assert issue.status == "Needs Triage"
+        # Check that the Jira issue is in Needs Triage.
+        assert issue.status == "Needs Triage"
+    else:
+        assert issue_id is None
+        assert len(fake_jira.issues) == 0
 
     # Check that we synchronized labels.
-    sync_labels_fn.assert_called_once_with("edx/some-code")
+    sync_labels_fn.assert_called_once_with(f"edx/some-code")
 
     # Check the GitHub comment that was created.
     pr_comments = pr.list_comments()
     assert len(pr_comments) == 1
     body = pr_comments[0].body
-    jira_link = "[{id}](https://test.atlassian.net/browse/{id})".format(id=issue_id)
-    assert jira_link in body
+    check_issue_link_in_markdown(body, issue_id)
     assert "Thanks for the pull request, @tusbar!" in body
     assert is_comment_kind(BotComment.WELCOME, body)
     assert not is_comment_kind(BotComment.NEED_CLA, body)
     assert is_comment_kind(BotComment.OK_TO_TEST, body)
 
     # Check the GitHub labels that got applied.
-    assert pr.labels == {"needs triage", "open-source-contribution"}
+    expected_labels = {"open-source-contribution"}
+    if has_jira:
+        expected_labels.add("needs triage")
+    assert pr.labels == expected_labels
 
     # Check the status check applied to the latest commit.
     assert pr.status(CLA_CONTEXT) == CLA_STATUS_GOOD
@@ -211,9 +225,12 @@ def test_external_pr_opened_with_cla(reqctx, sync_labels_fn, fake_github, fake_j
     pr_comments = pr.list_comments()
     assert len(pr_comments) == 1
 
-    issue = fake_jira.issues[issue_id]
-    # Re-opening a pull request should put Jira back its state before the closing.
-    assert issue.status == "Needs Triage"
+    if has_jira:
+        issue = fake_jira.issues[issue_id]
+        # Re-opening a pull request should put Jira back its state before the closing.
+        assert issue.status == "Needs Triage"
+    else:
+        assert len(fake_jira.issues) == 0
 
 
 def test_psycho_reopening(reqctx, sync_labels_fn, fake_github, fake_jira):
@@ -236,49 +253,55 @@ def test_psycho_reopening(reqctx, sync_labels_fn, fake_github, fake_jira):
         assert issue.status == status
 
 
-def test_core_committer_pr_opened(reqctx, sync_labels_fn, fake_github, fake_jira):
+def test_core_committer_pr_opened(has_jira, reqctx, sync_labels_fn, fake_github, fake_jira):
     pr = fake_github.make_pull_request(user="felipemontoya", owner="edx", repo="edx-platform")
     prj = pr.as_json()
 
     with reqctx:
         issue_id, anything_happened = pull_request_changed(prj)
 
-    assert issue_id is not None
-    assert issue_id.startswith("OSPR-")
     assert anything_happened is True
+    if has_jira:
+        assert issue_id is not None
+        assert issue_id.startswith("OSPR-")
 
-    # Check the Jira issue that was created.
-    assert len(fake_jira.issues) == 1
-    issue = fake_jira.issues[issue_id]
-    assert issue.contributor_name == "Felipe Montoya"
-    assert issue.customer == ["EduNEXT"]
-    assert issue.pr_number == prj["number"]
-    assert issue.repo == prj["base"]["repo"]["full_name"]
-    assert issue.url == prj["html_url"]
-    assert issue.description == prj["body"]
-    assert issue.issuetype == "Pull Request Review"
-    assert issue.summary == prj["title"]
-    assert issue.labels == {"core-committer"}
+        # Check the Jira issue that was created.
+        assert len(fake_jira.issues) == 1
+        issue = fake_jira.issues[issue_id]
+        assert issue.contributor_name == "Felipe Montoya"
+        assert issue.customer == ["EduNEXT"]
+        assert issue.pr_number == prj["number"]
+        assert issue.repo == prj["base"]["repo"]["full_name"]
+        assert issue.url == prj["html_url"]
+        assert issue.description == prj["body"]
+        assert issue.issuetype == "Pull Request Review"
+        assert issue.summary == prj["title"]
+        assert issue.labels == {"core-committer"}
 
-    # Check that the Jira issue was moved to Waiting on Author
-    assert issue.status == "Waiting on Author"
+        # Check that the Jira issue was moved to Waiting on Author
+        assert issue.status == "Waiting on Author"
+    else:
+        assert issue_id is None
+        assert len(fake_jira.issues) == 0
 
     # Check that we synchronized labels.
-    sync_labels_fn.assert_called_once_with("edx/edx-platform")
+    sync_labels_fn.assert_called_once_with(f"edx/edx-platform")
 
     # Check the GitHub comment that was created.
     pr_comments = pr.list_comments()
     assert len(pr_comments) == 1
     body = pr_comments[0].body
-    jira_link = "[{id}](https://test.atlassian.net/browse/{id})".format(id=issue_id)
-    assert jira_link in body
+    check_issue_link_in_markdown(body, issue_id)
     assert "Thanks for the pull request, @felipemontoya!" in body
     assert is_comment_kind(BotComment.CORE_COMMITTER, body)
     assert not is_comment_kind(BotComment.NEED_CLA, body)
     assert is_comment_kind(BotComment.OK_TO_TEST, body)
 
     # Check the GitHub labels that got applied.
-    assert pr.labels == {"waiting on author", "open-source-contribution", "core committer"}
+    expected_labels = {"open-source-contribution", "core committer"}
+    if has_jira:
+        expected_labels.add("waiting on author")
+    assert pr.labels == expected_labels
     # Check the status check applied to the latest commit.
     assert pr.status(CLA_CONTEXT) == CLA_STATUS_GOOD
     # It should have been put in the OSPR project.
@@ -307,8 +330,7 @@ def test_old_core_committer_pr_opened(reqctx, sync_labels_fn, fake_github, fake_
     pr_comments = pr.list_comments()
     assert len(pr_comments) == 1
     body = pr_comments[0].body
-    jira_link = "[{id}](https://test.atlassian.net/browse/{id})".format(id=issue_id)
-    assert jira_link in body
+    check_issue_link_in_markdown(body, issue_id)
     assert "Thanks for the pull request, @felipemontoya!" in body
     assert not is_comment_kind(BotComment.CORE_COMMITTER, body)
     assert not is_comment_kind(BotComment.NEED_CLA, body)
@@ -333,7 +355,7 @@ EXAMPLE_PLATFORM_MAP_1_2 = {
     pytest.param(False, id="epic:no"),
     pytest.param(True, id="epic:yes"),
 ])
-def test_blended_pr_opened_with_cla(with_epic, reqctx, sync_labels_fn, fake_github, fake_jira):
+def test_blended_pr_opened_with_cla(with_epic, has_jira, reqctx, sync_labels_fn, fake_github, fake_jira):
     pr = fake_github.make_pull_request(owner="edx", repo="some-code", user="tusbar", title="[BD-34] Something good")
     prj = pr.as_json()
     total_issues = 0
@@ -349,50 +371,56 @@ def test_blended_pr_opened_with_cla(with_epic, reqctx, sync_labels_fn, fake_gith
     with reqctx:
         issue_id, anything_happened = pull_request_changed(prj)
 
-    assert issue_id is not None
-    assert issue_id.startswith("BLENDED-")
     assert anything_happened is True
+    if has_jira:
+        assert issue_id is not None
+        assert issue_id.startswith("BLENDED-")
 
-    # Check the Jira issue that was created.
-    assert len(fake_jira.issues) == total_issues + 1
-    issue = fake_jira.issues[issue_id]
-    assert issue.contributor_name == "Bertrand Marron"
-    assert issue.customer == ["IONISx"]
-    assert issue.pr_number == prj["number"]
-    assert issue.repo == "edx/some-code"
-    assert issue.url == prj["html_url"]
-    assert issue.description == prj["body"]
-    assert issue.issuetype == "Pull Request Review"
-    assert issue.summary == prj["title"]
-    assert issue.labels == {"blended"}
-    if with_epic:
-        assert issue.epic_link == epic.key
-        assert issue.platform_map_1_2 == EXAMPLE_PLATFORM_MAP_1_2
+        # Check the Jira issue that was created.
+        assert len(fake_jira.issues) == total_issues + 1
+        issue = fake_jira.issues[issue_id]
+        assert issue.contributor_name == "Bertrand Marron"
+        assert issue.customer == ["IONISx"]
+        assert issue.pr_number == prj["number"]
+        assert issue.repo == f"edx/some-code"
+        assert issue.url == prj["html_url"]
+        assert issue.description == prj["body"]
+        assert issue.issuetype == "Pull Request Review"
+        assert issue.summary == prj["title"]
+        assert issue.labels == {"blended"}
+        if with_epic:
+            assert issue.epic_link == epic.key
+            assert issue.platform_map_1_2 == EXAMPLE_PLATFORM_MAP_1_2
+        else:
+            assert issue.epic_link is None
+            assert issue.platform_map_1_2 is None
+
+        # Check that the Jira issue is in Needs Triage.
+        assert issue.status == "Needs Triage"
     else:
-        assert issue.epic_link is None
-        assert issue.platform_map_1_2 is None
-
-    # Check that the Jira issue is in Needs Triage.
-    assert issue.status == "Needs Triage"
+        assert issue_id is None
+        assert len(fake_jira.issues) == total_issues
 
     # Check that we synchronized labels.
-    sync_labels_fn.assert_called_once_with("edx/some-code")
+    sync_labels_fn.assert_called_once_with(f"edx/some-code")
 
     # Check the GitHub comment that was created.
     pr_comments = pr.list_comments()
     assert len(pr_comments) == 1
     body = pr_comments[0].body
-    jira_link = "[{id}](https://test.atlassian.net/browse/{id})".format(id=issue_id)
-    assert jira_link in body
+    check_issue_link_in_markdown(body, issue_id)
     assert "Thanks for the pull request, @tusbar!" in body
     has_project_link = "the [BD-34](https://thewiki/bd-34) project page" in body
-    assert has_project_link == with_epic
+    assert has_project_link == (with_epic and has_jira)
     assert is_comment_kind(BotComment.BLENDED, body)
     assert not is_comment_kind(BotComment.NEED_CLA, body)
     assert is_comment_kind(BotComment.OK_TO_TEST, body)
 
     # Check the GitHub labels that got applied.
-    assert pr.labels == {"needs triage", "blended"}
+    expected_labels = {"blended"}
+    if has_jira:
+        expected_labels.add("needs triage")
+    assert pr.labels == expected_labels
     # Check the status check applied to the latest commit.
     assert pr.status(CLA_CONTEXT) == CLA_STATUS_GOOD
     # It should have been put in the Blended project.
@@ -655,7 +683,7 @@ def test_title_change_but_issue_already_moved(reqctx, fake_github, fake_jira):
     pytest.param(False, id="jira:notfiddled"),
     pytest.param(True, id="jira:fiddled"),
 ])
-def test_draft_pr_opened(pr_type, jira_got_fiddled, reqctx, fake_github, fake_jira):
+def test_draft_pr_opened(pr_type, jira_got_fiddled, has_jira, reqctx, fake_github, fake_jira):
     # Open a WIP pull request.
     title1 = "WIP: broken"
     title2 = "Fixed and done"
@@ -681,31 +709,35 @@ def test_draft_pr_opened(pr_type, jira_got_fiddled, reqctx, fake_github, fake_ji
     with reqctx:
         issue_id, anything_happened = pull_request_changed(prj)
 
-    assert issue_id is not None
-    assert issue_id.startswith("BLENDED-" if pr_type == "blended" else "OSPR-")
     assert anything_happened is True
+    if has_jira:
+        assert issue_id is not None
+        assert issue_id.startswith("BLENDED-" if pr_type == "blended" else "OSPR-")
 
-    # Check the Jira issue that was created.
-    assert len(fake_jira.issues) == 1
-    issue = fake_jira.issues[issue_id]
-    assert issue.issuetype == "Pull Request Review"
-    assert issue.summary == prj["title"]
-    if pr_type == "normal":
-        assert issue.labels == set()
-    elif pr_type == "blended":
-        assert issue.labels == {"blended"}
-    elif pr_type == "committer":
-        assert issue.labels == {"core-committer"}
-    else:
-        assert pr_type == "nocla"
-        assert issue.labels == set()
+        # Check the Jira issue that was created.
+        assert len(fake_jira.issues) == 1
+        issue = fake_jira.issues[issue_id]
+        assert issue.issuetype == "Pull Request Review"
+        assert issue.summary == prj["title"]
+        if pr_type == "normal":
+            assert issue.labels == set()
+        elif pr_type == "blended":
+            assert issue.labels == {"blended"}
+        elif pr_type == "committer":
+            assert issue.labels == {"core-committer"}
+        else:
+            assert pr_type == "nocla"
+            assert issue.labels == set()
 
-    # Because of "WIP", the Jira issue is in "Waiting on Author", unless
-    # there's no CLA.
-    if pr_type == "nocla":
-        assert issue.status == "Community Manager Review"
+        # Because of "WIP", the Jira issue is in "Waiting on Author", unless
+        # there's no CLA.
+        if pr_type == "nocla":
+            assert issue.status == "Community Manager Review"
+        else:
+            assert issue.status == "Waiting on Author"
     else:
-        assert issue.status == "Waiting on Author"
+        assert issue_id is None
+        assert len(fake_jira.issues) == 0
 
     # Check the GitHub comment that was created.
     pr_comments = pr.list_comments()
@@ -713,22 +745,23 @@ def test_draft_pr_opened(pr_type, jira_got_fiddled, reqctx, fake_github, fake_ji
     body = pr_comments[0].body
     assert 'This is currently a draft pull request' in body
     assert 'click "Ready for Review"' in body
+    expected_labels = set()
+    expected_labels.add("blended" if pr_type == "blended" else "open-source-contribution")
+    if has_jira:
+        expected_labels.add("community manager review" if pr_type == "nocla" else "waiting on author")
+    if pr_type == "committer":
+        expected_labels.add("core committer")
+    assert pr.labels == expected_labels
     if pr_type == "normal":
         assert is_comment_kind(BotComment.WELCOME, body)
-        assert pr.labels == {"waiting on author", "open-source-contribution"}
     elif pr_type == "blended":
         assert is_comment_kind(BotComment.BLENDED, body)
-        assert pr.labels == {"waiting on author", "blended"}
     elif pr_type == "committer":
         assert is_comment_kind(BotComment.CORE_COMMITTER, body)
-        assert pr.labels == {"waiting on author", "core committer", "open-source-contribution"}
     else:
         assert pr_type == "nocla"
         assert is_comment_kind(BotComment.NEED_CLA, body)
-        assert pr.labels == {
-            'community manager review',
-            'open-source-contribution',
-        }
+
     # Check the status check applied to the latest commit.
     assert pr.status(CLA_CONTEXT) == (CLA_STATUS_BAD if pr_type == "nocla" else CLA_STATUS_GOOD)
     if pr_type == "blended":
@@ -738,7 +771,7 @@ def test_draft_pr_opened(pr_type, jira_got_fiddled, reqctx, fake_github, fake_ji
         assert pr.is_in_project(settings.GITHUB_OSPR_PROJECT)
         assert not pr.is_in_project(settings.GITHUB_BLENDED_PROJECT)
 
-    if jira_got_fiddled:
+    if has_jira and jira_got_fiddled:
         # Someone changes the status from "Waiting on Author" manually.
         issue.status = "Architecture Review"
 
@@ -748,8 +781,11 @@ def test_draft_pr_opened(pr_type, jira_got_fiddled, reqctx, fake_github, fake_ji
         issue_id2, _ = pull_request_changed(pr.as_json())
 
     assert issue_id2 == issue_id
-    issue = fake_jira.issues[issue_id]
-    assert issue.summary == title2
+    if has_jira:
+        issue = fake_jira.issues[issue_id]
+        assert issue.summary == title2
+    else:
+        assert len(fake_jira.issues) == 0
 
     pr_comments = pr.list_comments()
     assert len(pr_comments) == 1
@@ -757,13 +793,14 @@ def test_draft_pr_opened(pr_type, jira_got_fiddled, reqctx, fake_github, fake_ji
     assert 'This is currently a draft pull request' not in body
     assert 'click "Ready for Review"' not in body
 
-    if jira_got_fiddled:
-        assert issue.status == "Architecture Review"
-        assert "architecture review" in pr.labels
-        assert initial_status.lower() not in pr.labels
-    else:
-        assert issue.status == initial_status
-        assert initial_status.lower() in pr.labels
+    if has_jira:
+        if jira_got_fiddled:
+            assert issue.status == "Architecture Review"
+            assert "architecture review" in pr.labels
+            assert initial_status.lower() not in pr.labels
+        else:
+            assert issue.status == initial_status
+            assert initial_status.lower() in pr.labels
 
     # Oops, it goes back to draft!
     pr.title = title1
@@ -771,8 +808,11 @@ def test_draft_pr_opened(pr_type, jira_got_fiddled, reqctx, fake_github, fake_ji
         issue_id3, _ = pull_request_changed(pr.as_json())
 
     assert issue_id3 == issue_id
-    issue = fake_jira.issues[issue_id]
-    assert issue.summary == title1
+    if has_jira:
+        issue = fake_jira.issues[issue_id]
+        assert issue.summary == title1
+    else:
+        assert len(fake_jira.issues) == 0
 
     pr_comments = pr.list_comments()
     assert len(pr_comments) == 1
@@ -780,48 +820,52 @@ def test_draft_pr_opened(pr_type, jira_got_fiddled, reqctx, fake_github, fake_ji
     assert 'This is currently a draft pull request' in body
     assert 'click "Ready for Review"' in body
 
-    if jira_got_fiddled:
-        # We don't change the Jira status again if the PR goes back to draft.
-        assert issue.status == "Architecture Review"
-        assert "architecture review" in pr.labels
-        assert initial_status.lower() not in pr.labels
-    else:
-        assert issue.status == initial_status
-        assert initial_status.lower() in pr.labels
+    if has_jira:
+        if jira_got_fiddled:
+            # We don't change the Jira status again if the PR goes back to draft.
+            assert issue.status == "Architecture Review"
+            assert "architecture review" in pr.labels
+            assert initial_status.lower() not in pr.labels
+        else:
+            assert issue.status == initial_status
+            assert initial_status.lower() in pr.labels
 
 
-def test_handle_closed_pr(reqctx, sync_labels_fn, fake_github, fake_jira, is_merged):
+def test_handle_closed_pr(is_merged, has_jira, reqctx, sync_labels_fn, fake_github, fake_jira):
     pr = fake_github.make_pull_request(user="tusbar", number=11237, state="closed", merged=is_merged)
     prj = pr.as_json()
 
     with reqctx:
         issue_id1, anything_happened = pull_request_changed(prj)
 
-    assert issue_id1 is not None
-    assert issue_id1.startswith("OSPR-")
     assert anything_happened is True
+    if has_jira:
+        assert issue_id1 is not None
+        assert issue_id1.startswith("OSPR-")
 
-    # Check the Jira issue that was created.
-    assert len(fake_jira.issues) == 1
-    issue = fake_jira.issues[issue_id1]
-    assert issue.contributor_name == "Bertrand Marron"
-    assert issue.customer == ["IONISx"]
-    assert issue.pr_number == 11237
-    assert issue.url == prj["html_url"]
-    assert issue.description == prj["body"]
-    assert issue.issuetype == "Pull Request Review"
-    assert issue.summary == prj["title"]
-    assert issue.labels == set()
+        # Check the Jira issue that was created.
+        assert len(fake_jira.issues) == 1
+        issue = fake_jira.issues[issue_id1]
+        assert issue.contributor_name == "Bertrand Marron"
+        assert issue.customer == ["IONISx"]
+        assert issue.pr_number == 11237
+        assert issue.url == prj["html_url"]
+        assert issue.description == prj["body"]
+        assert issue.issuetype == "Pull Request Review"
+        assert issue.summary == prj["title"]
+        assert issue.labels == set()
 
-    # Check that the Jira issue is in the right state.
-    assert issue.status == ("Merged" if is_merged else "Rejected")
+        # Check that the Jira issue is in the right state.
+        assert issue.status == ("Merged" if is_merged else "Rejected")
+    else:
+        assert issue_id1 is None
+        assert len(fake_jira.issues) == 0
 
     # Check the GitHub comment that was created.
     pr_comments = pr.list_comments()
     assert len(pr_comments) == 1
     body = pr_comments[0].body
-    jira_link = "[{id}](https://test.atlassian.net/browse/{id})".format(id=issue_id1)
-    assert jira_link in body
+    check_issue_link_in_markdown(body, issue_id1)
     if is_merged:
         assert "Although this pull request is already merged," in body
     else:
@@ -832,11 +876,15 @@ def test_handle_closed_pr(reqctx, sync_labels_fn, fake_github, fake_jira, is_mer
     assert is_comment_kind(BotComment.OK_TO_TEST, body)
 
     # Check the GitHub labels that got applied.
-    assert pr.labels == {("merged" if is_merged else "rejected"), "open-source-contribution"}
+    expected_labels = {"open-source-contribution"}
+    if has_jira:
+        expected_labels.add("merged" if is_merged else "rejected")
+    assert pr.labels == expected_labels
     assert pr.is_in_project(settings.GITHUB_OSPR_PROJECT)
     assert not pr.is_in_project(settings.GITHUB_BLENDED_PROJECT)
 
     # Rescan the pull request.
+    num_issues = len(fake_jira.issues)
     with reqctx:
         issue_id2, anything_happened2 = pull_request_changed(pr.as_json())
 
@@ -844,7 +892,7 @@ def test_handle_closed_pr(reqctx, sync_labels_fn, fake_github, fake_jira, is_mer
     assert anything_happened2 is False
 
     # No Jira issue was created.
-    assert len(fake_jira.issues) == 1
+    assert len(fake_jira.issues) == num_issues
 
     # No new GitHub comment was created.
     assert len(pr.list_comments()) == 1

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -603,7 +603,7 @@ def test_title_change_changes_jira_project(reqctx, fake_github, fake_jira):
     assert issue.status == "Needs Triage"
 
     # The pull request has to be associated with the new issue.
-    assert get_jira_issue_key(prj) == issue_id
+    assert get_jira_issue_key(prj) == (True, issue_id)
 
     # The pull request still has the ad-hoc label.
     assert "pretty" in pr.labels
@@ -675,7 +675,7 @@ def test_title_change_but_issue_already_moved(reqctx, fake_github, fake_jira):
     assert issue.status == "Needs Triage"
 
     # The pull request has to be associated with the new issue.
-    assert get_jira_issue_key(prj) == issue_id
+    assert get_jira_issue_key(prj) == (True, issue_id)
 
 
 @pytest.mark.parametrize("pr_type", ["normal", "blended", "committer", "nocla"])


### PR DESCRIPTION
This change makes it possible to disable accessing Jira, or to have pull requests opened when one Jira server is connected, and then be closed when a different Jira server is connected.