### PR TITLE
docs: Add more detail for when CLA Checks fail.

### DIFF
--- a/openedx_webhooks/templates/github_community_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment.md.j2
@@ -42,6 +42,13 @@ Please let us know once your PR is ready for our review and all tests are green.
     for details.
     {%- endfilter %}
 
+
+    {%- filter replace("\n", " ")|trim %}
+    Once you've signed the CLA, please allow 1 business day for it to be processed.  After this time, you can re-run the
+    CLA check by editing the PR title.  If the problem persists, you can tag the `@openedx/cla-problems` team in a comment on your PR for further
+    assistance.
+    {%- endfilter %}
+
 <!-- comment:no_cla -->
 {% endif %}
 


### PR DESCRIPTION
Give users a way to re-run CLA checks themselves, and give them a way to
escalate CLA issues themselves.
