### PR TITLE
fix: Get more commits by default.

### DIFF
--- a/openedx_webhooks/github/dispatcher/actions/utils.py
+++ b/openedx_webhooks/github/dispatcher/actions/utils.py
@@ -45,7 +45,7 @@ def _get_latest_commit_for_pull_request_data(repo_name_full: str, number: int) -
     """
     url = f"https://api.github.com/repos/{repo_name_full}/pulls/{number}/commits"
     logger.debug("CLA: GET %s", url)
-    response = get_github_session().get(url)
+    response = get_github_session().get(url, params={"per_page": 100})
     log_check_response(response)
     data = response.json()
     logger.debug("CLA: GOT %s", data)


### PR DESCRIPTION
The commits api only gets 30 commits.  Up the default number of commits
we get to 100 in case someone has a long running branch.

Long term we should add paging to this endpoint but this should fix it
in most cases.  The function currently returns the full JSON payload so
we'll need to update the return signature if we want to start using
paging here.  This may impact callers so we defer that work for now.
