### PR TITLE
feat!: Stop syncing labels between Jira and github.

### DIFF
--- a/openedx_webhooks/labels.py
+++ b/openedx_webhooks/labels.py
@@ -7,18 +7,6 @@ by which authority. This is that information.
 # be used at a time.
 
 GITHUB_STATUS_LABELS = {
-    "architecture review",
-    "awaiting prioritization",
-    "blocked by other work",
-    "changes requested",
-    "community manager review",
-    "engineering review",
-    "merged",
-    "needs triage",
-    "open edx community review",
-    "product review",
-    "rejected",
-    "waiting on author",
 }
 
 # These are categorization labels the bot assigns based on other information.

--- a/openedx_webhooks/labels.py
+++ b/openedx_webhooks/labels.py
@@ -6,8 +6,7 @@ by which authority. This is that information.
 # These are labels that correspond to Jira statuses.  Only one of them should
 # be used at a time.
 
-GITHUB_STATUS_LABELS = {
-}
+GITHUB_STATUS_LABELS = set()
 
 # These are categorization labels the bot assigns based on other information.
 

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -30,7 +30,6 @@ def sync_labels_fn(mocker):
     """A patch on synchronize_labels"""
     return mocker.patch("openedx_webhooks.tasks.github_work.synchronize_labels")
 
-
 def close_and_reopen_pr(pr):
     """For testing re-opening, close the pr, process it, then re-open it."""
     pr.close(merge=False)
@@ -661,7 +660,18 @@ def test_title_change_but_issue_already_moved(fake_github, fake_jira):
     pytest.param(False, id="jira:notfiddled"),
     pytest.param(True, id="jira:fiddled"),
 ])
-def test_draft_pr_opened(pr_type, jira_got_fiddled, has_jira, fake_github, fake_jira):
+def test_draft_pr_opened(pr_type, jira_got_fiddled, has_jira, fake_github, fake_jira, mocker):
+
+    # Set the GITHUB_STATUS_LABEL variable with a set() of labels that should map to jira issues.
+    # We set this explicitly here because the production version of the list can change and we don't
+    # want that to break the test.
+    github_status_labels = {
+        "needs triage",
+        "waiting on author",
+        "community manager review",
+    }
+    mocker.patch("openedx_webhooks.tasks.pr_tracking.GITHUB_STATUS_LABELS", github_status_labels)
+
     # Open a WIP pull request.
     title1 = "WIP: broken"
     title2 = "Fixed and done"


### PR DESCRIPTION
BREAKING CHANGE: All labels are considered ad-hoc and we don't
automatically remove any labels that might have been added manually.
