### PR TITLE
feat: no longer read the obsolete `internal` setting in orgs.yaml

### DIFF
--- a/changelog.d/20230302_152318_nedbat_no_more_internal.rst
+++ b/changelog.d/20230302_152318_nedbat_no_more_internal.rst
@@ -1,0 +1,4 @@
+.. A new scriv changelog fragment.
+
+- Removed the code that used the now-obsolete ``internal`` setting in
+  orgs.yaml.

--- a/openedx_webhooks/github/dispatcher/actions/utils.py
+++ b/openedx_webhooks/github/dispatcher/actions/utils.py
@@ -109,7 +109,7 @@ CLA_DETAIL_URL = "https://openedx.atlassian.net/wiki/spaces/COMM/pages/941457737
 CLA_STATUS_GOOD = {
     "context": CLA_CONTEXT,
     "state": "success",
-    "description": "The author is covered by a Contributor Agreement",
+    "description": "The author is authorized to contribute",
     "target_url": CLA_DETAIL_URL,
 }
 
@@ -136,7 +136,7 @@ CLA_STATUS_PRIVATE = {
 CLA_STATUS_NO_CONTRIBUTIONS = {
     "context": CLA_CONTEXT,
     "state": "failure",
-    "description": "This repo does not accept contributions",
+    "description": "This repo does not accept outside contributions except under contract",
 }
 
 

--- a/openedx_webhooks/tasks/pr_tracking.py
+++ b/openedx_webhooks/tasks/pr_tracking.py
@@ -244,11 +244,12 @@ def desired_support_state(pr: PrDict) -> Optional[PrDesiredInfo]:
 
     user_is_bot = is_bot_pull_request(pr)
     no_cla_is_needed = is_private_repo_no_cla_pull_request(pr)
+    is_internal = is_internal_pull_request(pr)
     if user_is_bot:
         logger.info(f"@{user} is a bot, not an ospr.")
     elif no_cla_is_needed:
         logger.info(f"{repo}#{num} (@{user}) is in a private repo, not an ospr")
-    elif is_internal_pull_request(pr):
+    elif is_internal:
         logger.info(f"@{user} acted on {repo}#{num}, internal PR, not an ospr")
     elif repo_refuses_contributions(pr):
         desired.is_refused = True
@@ -314,7 +315,7 @@ def desired_support_state(pr: PrDict) -> Optional[PrDesiredInfo]:
     elif desired.is_refused:
         desired.cla_check = CLA_STATUS_NO_CONTRIBUTIONS
         desired.is_ospr = False
-    elif has_signed_agreement:
+    elif is_internal or has_signed_agreement:
         desired.cla_check = CLA_STATUS_GOOD
     else:
         desired.cla_check = CLA_STATUS_BAD

--- a/openedx_webhooks/templates/no_contributions.md.j2
+++ b/openedx_webhooks/templates/no_contributions.md.j2
@@ -1,6 +1,5 @@
 {% filter replace("\n", " ")|trim %}
-Thanks for your pull request, but this repo is not accepting outside contributions.
-
+Thanks for your pull request, but this repo does not accept outside contributions unless they are under contract.
 If you think this is an error, please contact @nedbat.
 {% endfilter %}
 

--- a/tests/repo_data/openedx/openedx-webhooks-data/orgs.yaml
+++ b/tests/repo_data/openedx/openedx-webhooks-data/orgs.yaml
@@ -9,9 +9,6 @@ EduNEXT:
     contact:
         name: Luis Felipe Montoya
         email: contact@edunext.co
-InternalOrg:
-    agreement: institution
-    internal: True
 MIT:
     contractor: false
     agreement: institution

--- a/tests/repo_data/openedx/openedx-webhooks-data/salesforce-export.csv
+++ b/tests/repo_data/openedx/openedx-webhooks-data/salesforce-export.csv
@@ -1,7 +1,6 @@
 "First Name","Last Name","Number of Active Ind. CLA Contracts","Title","Account Name","Number of Active Entity CLA Contracts","GitHub Username"
 "Xavier","Antoviaque","","","OpenCraft","","antoviaque"
 "Feanil","Patel","","","tCRIL","","feanil"
-"Internal","Guy","","","InternalOrg","","intguy"
 "Felipe","Montoya","","","EduNEXT","","felipemontoya"
 "Holly","Hunter","","","Individual Contributors","","hollyhunter"
 "John","Jarvis","","","Individual Contributors","","jarv"

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -45,12 +45,6 @@ def test_tcril_employee(make_pull_request):
     pr = make_pull_request("feanil", repo="edx/something")
     assert not is_internal_pull_request(pr)
 
-def test_intguy(make_pull_request):
-    pr = make_pull_request("intguy", repo="anywhere/anything")
-    assert is_internal_pull_request(pr)
-    pr = make_pull_request("intguy", repo="edx/something")
-    assert is_internal_pull_request(pr)
-
 def test_ex_edx_employee(make_pull_request):
     pr = make_pull_request("mmprandom")
     assert not is_internal_pull_request(pr)

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -69,9 +69,10 @@ def test_pr_in_private_repo_opened(fake_github, fake_jira):
     assert pull_request_projects(pr.as_json()) == set()
 
 
-def test_pr_in_nocontrib_repo_opened(fake_github, fake_jira):
+@pytest.mark.parametrize("user", ["tusbar", "feanil"])
+def test_pr_in_nocontrib_repo_opened(fake_github, fake_jira, user):
     repo = fake_github.make_repo("edx", "some-public-repo")
-    pr = repo.make_pull_request(user="tusbar")
+    pr = repo.make_pull_request(user=user)
     key, anything_happened = pull_request_changed(pr.as_json())
     assert key is None
     assert anything_happened is True


### PR DESCRIPTION
- Remove code that checked obsolete `internal` setting
- Tweak the wording of cla check messages