### PR TITLE
feat: support running CLA check in merge queues

### DIFF
--- a/openedx_webhooks/github_views.py
+++ b/openedx_webhooks/github_views.py
@@ -95,7 +95,7 @@ def hook_receiver():
     pr["hook_action"] = event["action"]
 
     pr_activity = f"{repo} #{pr_number} {action!r}"
-    if action in ["opened", "edited", "closed", "synchronize", "ready_for_review", "converted_to_draft", "reopened"]:
+    if action in ["opened", "edited", "closed", "synchronize", "ready_for_review", "converted_to_draft", "reopened", "enqueued"]:
         logger.info(f"{pr_activity}, processing...")
         result = pull_request_changed_task.delay(pr, wsgi_environ=minimal_wsgi_environ())
     else:


### PR DESCRIPTION
When a repo within the openedx org is configured to use merge queues, a CLA check response is requested for each PR in the queue. This check was never being run, leading to the PR being removed from the queue. This updates the hook to support the enqueued action type for PRs to ensure the check is run for PRs in the queue.