### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/openedx_webhooks/templates/github_community_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment.md.j2
@@ -35,7 +35,7 @@ Please let us know once your PR is ready for our review and all tests are green.
     {%- filter replace("\n", " ")|trim %}
     :warning: We can't start reviewing your pull request until you've submitted a
     [signed contributor agreement](https://openedx.org/cla)
-    or indicated your institutional affiliation. Please see the [CONTRIBUTING](https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst)
+    or indicated your institutional affiliation. Please see the [CONTRIBUTING](https://github.com/openedx/.github/blob/master/CONTRIBUTING.md)
     file for more information.
     If you've signed an agreement in the past, you may need to re-sign.  See
     [The New Home of the Open edX Codebase](https://open.edx.org/blog/the-new-home-of-the-open-edx-codebase/)


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide.
