### PR TITLE
refactor: dispatch to functions for different activity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .cache
+.mypy_cache
 .coverage
 .data
 .env


### PR DESCRIPTION
In preparation for acting on comments, I've refactored the logic that picks apart webhook payloads.

This doesn't change any behavior (except perhaps what gets logged for things we don't care about), but I wanted get review incrementally.