### PR TITLE
feat: Use a TLS redis url if it's available.

### DIFF
--- a/openedx_webhooks/config.py
+++ b/openedx_webhooks/config.py
@@ -14,8 +14,8 @@ class DefaultConfig:
     CELERY_TASK_SERIALIZER = "json"
     CELERY_RESULT_SERIALIZER = "json"
     CELERY_EAGER_PROPAGATES = True
-    BROKER_URL = os.environ.get("REDIS_URL", "redis://")
-    CELERY_RESULT_BACKEND = os.environ.get("REDIS_URL", "redis://")
+    BROKER_URL = os.environ.get('REDIS_TLS_URL', os.environ.get("REDIS_URL", "redis://"))
+    CELERY_RESULT_BACKEND = os.environ.get('REDIS_TLS_URL', os.environ.get("REDIS_URL", "redis://"))
 
     def __init__(self):
         # Convert the heroku postgres URI to one that is compatible with SQLAlchemy

--- a/openedx_webhooks/lib/rq.py
+++ b/openedx_webhooks/lib/rq.py
@@ -7,7 +7,7 @@ import os
 import redis
 from rq import Queue
 
-_redis_url = os.environ.get('REDIS_URL', 'redis://')
+_redis_url = os.environ.get('REDIS_TLS_URL', os.environ.get('REDIS_URL', 'redis://'))
 
 # redis.Redis: Instance of a connected Redis store
 store = redis.from_url(_redis_url)


### PR DESCRIPTION
This is in preparation of an upgrade of the Redis server in production.

In production we use a premium redis server but it's running a fairly
old version of redis(4.x).  Heroku is about to drop support and force us
to use redis 7.x instead.  Before we do that, we want to make sure that
the server won't have any issues connecting to redis over a TLS
connection.  So we want to test it in staging first.

Unfortunately, n the staging environment we use the heroku redis mini
product.  This product allows for connecting over either a TLS
connection or a non-tls connection and provides a second environment
variable (REDIS_TLS_URL) if you want to connect to redis over TLS.  When
we upgrade production it will not provide this URL and the REDIS_URL
value will be secure by default.

So to validate we won't have issues in production, we force staging to
use the REDIS_TLS_URL if it's available but fallback to the REDIS_URL if
it is not available.

Related to https://github.com/openedx/openedx-webhooks/issues/238