### PR TITLE
refactor: move useful code out of github.dispatch.actions.utils

### DIFF
--- a/openedx_webhooks/github/dispatcher/actions/github_activity.py
+++ b/openedx_webhooks/github/dispatcher/actions/github_activity.py
@@ -6,7 +6,7 @@ from ....jira.tasks import update_latest_github_activity
 from ....lib.github.client import get_authenticated_gh_client
 from ....lib.jira.client import get_authenticated_jira_client
 from ...models import GithubEvent
-from .utils import find_issues_for_pull_request
+from ....tasks.jira_work import find_issues_for_pull_request
 
 EVENT_TYPES = (
     'issue_comment',

--- a/openedx_webhooks/tasks/jira_work.py
+++ b/openedx_webhooks/tasks/jira_work.py
@@ -22,6 +22,21 @@ def delete_jira_issue(issue_key):
     log_check_response(resp)
 
 
+def find_issues_for_pull_request(jira, pull_request_url):
+    """
+    Find corresponding JIRA issues for a given GitHub pull request.
+
+    Arguments:
+        jira (jira.JIRA): An authenticated JIRA API client session
+        pull_request_url (str)
+
+    Returns:
+        jira.client.ResultList[jira.Issue]
+    """
+    jql = 'project=OSPR AND cf[10904]="{}"'.format(pull_request_url)
+    return jira.search_issues(jql)
+
+
 def transition_jira_issue(issue_key, status_name):
     """
     Transition a Jira issue to a new status.

--- a/openedx_webhooks/tasks/pr_tracking.py
+++ b/openedx_webhooks/tasks/pr_tracking.py
@@ -24,11 +24,7 @@ from openedx_webhooks.bot_comments import (
     github_end_survey_comment,
     no_contributions_thanks,
 )
-from openedx_webhooks.gh_projects import (
-    add_pull_request_to_project,
-    pull_request_projects,
-)
-from openedx_webhooks.github.dispatcher.actions.utils import (
+from openedx_webhooks.cla_check import (
     CLA_STATUS_BAD,
     CLA_STATUS_BOT,
     CLA_STATUS_GOOD,
@@ -36,6 +32,10 @@ from openedx_webhooks.github.dispatcher.actions.utils import (
     CLA_STATUS_PRIVATE,
     cla_status_on_pr,
     set_cla_status_on_pr,
+)
+from openedx_webhooks.gh_projects import (
+    add_pull_request_to_project,
+    pull_request_projects,
 )
 from openedx_webhooks.info import (
     get_blended_project_id,

--- a/tests/fake_github.py
+++ b/tests/fake_github.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Set
 from urllib.parse import unquote
 
-from openedx_webhooks.github.dispatcher.actions.utils import CLA_CONTEXT
+from openedx_webhooks.cla_check import CLA_CONTEXT
 from openedx_webhooks.types import GhProject
 
 from . import faker

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -9,8 +9,7 @@ from openedx_webhooks.bot_comments import (
     BotComment,
     is_comment_kind,
 )
-from openedx_webhooks.gh_projects import pull_request_projects
-from openedx_webhooks.github.dispatcher.actions.utils import (
+from openedx_webhooks.cla_check import (
     CLA_CONTEXT,
     CLA_STATUS_BAD,
     CLA_STATUS_BOT,
@@ -18,6 +17,7 @@ from openedx_webhooks.github.dispatcher.actions.utils import (
     CLA_STATUS_NO_CONTRIBUTIONS,
     CLA_STATUS_PRIVATE,
 )
+from openedx_webhooks.gh_projects import pull_request_projects
 from openedx_webhooks.info import get_jira_issue_key
 from openedx_webhooks.tasks.github import pull_request_changed
 


### PR DESCRIPTION
One of the things slowing me down is my general distaste for the structure of the current code. I'm trying to be more aggressive about pulling it into a shape I like better.