### PR TITLE
feat!: stop adding `core committer` label

### DIFF
--- a/changelog.d/20230617_162500_kdmccormick_depr_core_committer_label.rst
+++ b/changelog.d/20230617_162500_kdmccormick_depr_core_committer_label.rst
@@ -1,0 +1,3 @@
+.. A new scriv changelog fragment.
+
+- Stopped the bot from adding the ``core committer`` GitHub label to pull requests to repos on which the bot believes the author to have write access. The bot's data source for repository access, ``people.yaml``, is outdated, we do not yet have a strategy for keeping it updated. Until further notice, coding Core Contributors are asked to add the ``core contributor`` label to their pull requests manually.

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -87,10 +87,10 @@ be changed.
   - Blended pull requests get "blended" applied as a GitHub label and Jira
     label.
 
-  - Core committer pull requests get "core-commiter" as a Jira label. They get
-    "core committer" and "open-source-contribution" as GitHub labels.
+  - Core committer pull requests get "core-commiter" as a Jira label and
+    "open-source-contribution" as a GitHub label.
 
-  - Regular pull requests get "open-source-contribution" as a GitHub label.
+  - Regular pull requests just get "open-source-contribution" as a GitHub label.
 
   - The initial Jira status is set as a GitHub label on the pull request.
 

--- a/openedx_webhooks/labels.py
+++ b/openedx_webhooks/labels.py
@@ -12,7 +12,6 @@ GITHUB_STATUS_LABELS: set[str] = set()
 
 GITHUB_CATEGORY_LABELS = {
     "blended",
-    "core committer",
     "open-source-contribution",
 }
 

--- a/openedx_webhooks/tasks/pr_tracking.py
+++ b/openedx_webhooks/tasks/pr_tracking.py
@@ -299,7 +299,6 @@ def desired_support_state(pr: PrDict) -> Optional[PrDesiredInfo]:
             desired.jira_labels.add("core-committer")
             desired.jira_initial_status = "Waiting on Author"
             desired.bot_comments.add(BotComment.CORE_COMMITTER)
-            desired.github_labels.add("core committer")
         desired.bot_comments.add(comment)
 
         assert settings.GITHUB_OSPR_PROJECT, "You must set GITHUB_OSPR_PROJECT"

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -301,7 +301,7 @@ def test_core_committer_pr_opened(has_jira, sync_labels_fn, fake_github, fake_ji
     assert is_comment_kind(BotComment.OK_TO_TEST, body)
 
     # Check the GitHub labels that got applied.
-    expected_labels = {"open-source-contribution", "core committer"}
+    expected_labels = {"open-source-contribution"}
     if has_jira:
         expected_labels.add("waiting on author")
     assert pr.labels == expected_labels


### PR DESCRIPTION
Stopped the bot from adding the `core committer` GitHub label
to pull requests to repos on which the bot believes the author
to have write access. The bot's data source for repository access,
`people.yaml`, is outdated, we do not yet have a strategy for
keeping it updated. Until further notice, coding Core Contributors
are asked to add the `core contributor` label to their pull requests
manually.

Another implication of `people.yaml` being oudated is that
the bot is not correctly choosing when to create Jira tickets,
which welcome/help message to post, etc. We are not addressing
that issue currently.

Part of: https://github.com/openedx/openedx-webhooks/issues/227