### PR TITLE
feat: commenting on a PR triggers updates and re-checks.

### DIFF
--- a/changelog.d/20230828_154558_nedbat_comment_to_check_cla.rst
+++ b/changelog.d/20230828_154558_nedbat_comment_to_check_cla.rst
@@ -1,0 +1,5 @@
+.. A new scriv changelog fragment.
+
+- Adding a comment to pull request now re-runs the checks and updates the state
+  of the pull request.  Previously, we'd edit the title of the PR to trigger
+  updates.


### PR DESCRIPTION
Ed asked for a simpler way to re-check the CLA than editing the title of the PR.  Now any comment on a PR will re-check the PR.  No special syntax needed.