### PR TITLE
fix: instructions shouldn't mention editing the PR title

### DIFF
--- a/openedx_webhooks/templates/github_community_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment.md.j2
@@ -46,7 +46,7 @@ Please let us know once your PR is ready for our review and all tests are green.
 
     {%- filter replace("\n", " ")|trim %}
     Once you've signed the CLA, please allow 1 business day for it to be processed.  After this time, you can re-run the
-    CLA check by editing the PR title.  If the problem persists, you can tag the `@openedx/cla-problems` team in a
+    CLA check by adding a comment here that you have signed it.  If the problem persists, you can tag the `@openedx/cla-problems` team in a
     comment on your PR for further assistance.
     {%- endfilter %}
 


### PR DESCRIPTION
The bot now re-checks when any comment is made to the PR.  Title editing isn't required.