### PR TITLE
refactor!: no longer create Jira issues when pull requests are created

### DIFF
--- a/docs/details.rst
+++ b/docs/details.rst
@@ -19,9 +19,6 @@ A number of aspects of the pull request are examined:
 
 The bot has to choose:
 
-- The Jira project to create the issue in,
-- The initial status of the Jira issue,
-- The Jira labels to apply to the issue,
 - The GitHub labels to apply to the pull request.
 
 Pull requests fall into a number of categories, which determine how it is
@@ -42,27 +39,7 @@ title, it is a draft pull request.
 
 Now we can decide what to do:
 
-- Create a Jira issue:
-
-  - Blended pull requests use the BLENDED Jira project.
-
-  - Others use OSPR.
-
-  - The Jira ticket has these fields:
-
-    - Issue type is "Pull Request Review".
-    - Summary is the title of the pull request.
-    - Description is the description of the pull request.
-    - URL is the GitHub URL of the pull request.
-    - PR Number is the number of the pull request.
-    - Repo is the name of the repo (like "edx/edx-platform").
-    - Contributor Name is the name of the author.
-    - Customer is the author's institution, if one is present in the database.
-    - Blended Jira issues also:
-
-      - have a link to their Blended epic
-
-- Initial Jira status:
+- Initial status:
 
   - Blended pull requests get "Needs Triage".
 
@@ -71,19 +48,16 @@ Now we can decide what to do:
     CLA, it is "Needs Triage".
 
 Draft pull requests start with a status of "Waiting on Author".  The initial
-Jira status determined above will be set once the pull request is no longer a
-draft, so long as the Jira issue is still in "Waiting for Author".  Note that
-if a pull request is later turned back into a draft, the Jira status will not
-be changed.
+status determined above will be set once the pull request is no longer a
+draft.
 
 - Labels:
 
-  - Blended pull requests get "blended" applied as a GitHub label and Jira
-    label.
+  - Blended pull requests get "blended" applied as a GitHub label.
 
   - Regular pull requests just get "open-source-contribution" as a GitHub label.
 
-  - The initial Jira status is set as a GitHub label on the pull request.
+  - The initial status is set as a GitHub label on the pull request.
 
 - Initial bot comment:
 
@@ -94,34 +68,9 @@ be changed.
 
 - Other information:
 
-  - A GitHub status check called "openedx/cla" is added to the latest commit.
+  - A GitHub commit status called "openedx/cla" is added to the latest commit.
     This is applied to all pull requests, even ones by authors internal to the
     pull request's organization.
-
-
-Updating Jira issue when pull requests change
----------------------------------------------
-
-Changes to pull requests are reflected in the Jira issue.  The titles and
-descriptions are copied over to the Jira issue if they are changed in GitHub.
-The number of lines added and deleted are updated if they have changed.
-
-If a change to a pull request means that a different Jira issue is needed, the
-old issue will be deleted, and a new one created.  For example, if a blended
-pull request doesn't have "[BD-xx]" in the title, an OSPR issue gets made
-initially.  When the developer updates the title, the bot deletes the OSPR
-issue and makes a new BLENDED issue for it.
-
-
-Updating GitHub labels when Jira status changes
------------------------------------------------
-
-The bot gets notifications from Jira when issues in either the OSPR or BLENDED
-project get updated.
-
-If the change is a status change, the bot finds the pull request based on
-fields in the issue. It removes the GitHub label for the old Jira status, and
-adds the GitHub label for the new Jira status.
 
 
 When a pull request is closed
@@ -135,8 +84,7 @@ When a pull request is re-opened
 --------------------------------
 
 The bot deletes the "please complete a survey" comment that was added when the
-pull request was closed.  The Jira issue is returned to the state it was in
-when the pull request was closed.
+pull request was closed.
 
 
 Adding pull requests to GitHub projects

--- a/openedx_webhooks/info.py
+++ b/openedx_webhooks/info.py
@@ -277,28 +277,6 @@ def get_jira_issue_key(pr: Union[PrId, PrDict]) -> Tuple[bool, Optional[str]]:
     return True, None
 
 
-def jira_project_for_ospr(_pr: PrDict) -> Optional[str]:
-    """
-    What Jira project should be used for this external pull request?
-
-    Returns a string or None if no Jira should be used.
-    """
-    if settings.JIRA_SERVER is None:
-        return None
-    return "OSPR"
-
-
-def jira_project_for_blended(_pr: PrDict) -> Optional[str]:
-    """
-    What Jira project should be used for this blended pull request?
-
-    Returns a string or None if no Jira should be used.
-    """
-    if settings.JIRA_SERVER is None:
-        return None
-    return "BLENDED"
-
-
 def get_catalog_info(repo_fullname: str) -> Dict:
     """Get the parsed catalog-info.yaml data from a repo, or {} if missing."""
     yml = _read_github_file(repo_fullname, "catalog-info.yaml", not_there="{}")

--- a/openedx_webhooks/tasks/jira_work.py
+++ b/openedx_webhooks/tasks/jira_work.py
@@ -9,17 +9,9 @@ import requests
 from openedx_webhooks.auth import get_jira_session
 from openedx_webhooks.tasks import logger
 from openedx_webhooks.utils import (
-    get_jira_custom_fields,
     log_check_response,
     sentry_extra_context,
 )
-
-def delete_jira_issue(issue_key):
-    """
-    Delete an issue from Jira.
-    """
-    resp = get_jira_session().delete(f"/rest/api/2/issue/{issue_key}")
-    log_check_response(resp)
 
 
 def find_issues_for_pull_request(jira, pull_request_url):
@@ -107,15 +99,12 @@ def update_jira_issue(
         summary: Optional[str]=None,
         description: Optional[str]=None,
         labels: Optional[List[str]]=None,
-        epic_link: Optional[str]=None,
-        extra_fields: Optional[Dict[str, str]]=None,
     ):
     """
     Update some fields on a Jira issue.
     """
     fields: Dict[str, Any] = {}
     notify = "false"
-    custom_fields = get_jira_custom_fields()
     if summary is not None:
         fields["summary"] = summary
         notify = "true"
@@ -124,11 +113,6 @@ def update_jira_issue(
         notify = "true"
     if labels is not None:
         fields["labels"] = labels
-    if epic_link is not None:
-        fields[custom_fields["Epic Link"]] = epic_link
-    if extra_fields is not None:
-        for name, value in extra_fields.items():
-            fields[custom_fields[name]] = value
     assert fields
     # Note: notifyUsers=false only works if the bot is an admin in the project.
     # Contrary to the docs, if the bot is not an admin, the setting isn't ignored,

--- a/openedx_webhooks/templates/github_blended_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_blended_pr_comment.md.j2
@@ -1,15 +1,5 @@
 {% filter replace("\n", " ")|trim %}
 Thanks for the pull request, @{{ user }}!
-{% if issue_key %}
-I've created [{{ issue_key }}]({{ jira_server }}/browse/{{ issue_key }})
-to keep track of it in Jira.
-{% endif %}
-{% if deleted_issue_key %}
-(The original issue {{ deleted_issue_key }} has been deleted.)
-{% endif %}
-{% if project_page %}
-More details are on the [{{ project_name }}]({{ project_page }}) project page.
-{% endif %}
 {% endfilter %}
 
 {% if is_draft %}

--- a/openedx_webhooks/templates/github_community_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment.md.j2
@@ -1,9 +1,5 @@
 {% filter replace("\n", " ")|trim %}
 Thanks for the pull request, @{{ user }}!
-{% if issue_key %}
-I've created [{{ issue_key }}]({{ jira_server }}/browse/{{ issue_key }})
-to keep track of it in JIRA, where we prioritize reviews.
-{% endif %}
 Please note that it may take us up to several weeks or months to complete a review and merge your PR.
 {% endfilter %}
 

--- a/openedx_webhooks/templates/github_community_pr_comment_closed.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment_closed.md.j2
@@ -1,13 +1,7 @@
 {% filter replace("\n", " ")|trim %}
 Although this pull request is already
 {% if is_merged %}merged{% else %}closed{% endif %},
-{% if issue_key %}
-I've created
-[{{ issue_key }}]({{ jira_server }}/browse/{{ issue_key }})
-so that we can track it in Jira.
-{% else %}
 I'm still watching it for updates.
-{% endif %}
 {% endfilter %}
 
 {% filter replace("\n", " ")|trim %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,16 +124,3 @@ def reset_all_memoized_functions():
 def is_merged(request):
     """Makes tests try both merged and closed pull requests."""
     return request.param
-
-
-@pytest.fixture(params=[
-    pytest.param(False, id="jira:no"),
-    pytest.param(True, id="jira:yes"),
-])
-def has_jira(request, mocker):
-    """Makes tests try both with and without accessing Jira."""
-    mocker.patch(
-        "openedx_webhooks.settings.JIRA_SERVER",
-        settings.TestSettings.JIRA_SERVER if request.param else None
-    )
-    return request.param

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,14 +1,7 @@
 """Helpers for tests."""
 
-import contextlib
 import random
 import re
-import unittest.mock
-from typing import Optional
-
-import requests_mock
-
-from .fake_jira import FakeJira
 
 
 def check_good_markdown(text: str) -> None:
@@ -98,23 +91,3 @@ def check_good_graphql(text: str) -> None:
             stack.pop()
     if stack:
         raise ValueError(f"GraphQL query has unbalanced parens: {text!r}")
-
-
-@contextlib.contextmanager
-def jira_server(server: Optional[str]):
-    """
-    Use a particular JIRA_SERVER for a chunk of code.
-
-    Args:
-        server: a string like "https://myjira.atlassian.net", or None for no
-            JIRA server.
-
-    """
-    with unittest.mock.patch("openedx_webhooks.settings.JIRA_SERVER", server):
-        # This uses real_http=True so that it layers properly on top of the
-        # outer Mocker: https://requests-mock.readthedocs.io/en/latest/mocker.html#nested-mockers
-        mocker = requests_mock.Mocker(real_http=True, case_sensitive=True)
-        the_fake_jira = FakeJira(server)
-        the_fake_jira.install_mocks(mocker)
-        with mocker:
-            yield the_fake_jira

--- a/tests/test_fake_jira.py
+++ b/tests/test_fake_jira.py
@@ -36,25 +36,12 @@ class TestIssues:
         # The body is unchanged.
         assert issue2["fields"]["description"] == "Here are the details so you can see how serious it is."
 
-    def test_delete_issue(self, fake_jira):
-        fake_jira.make_issue(key="HELLO-123", summary="This is a bad bug!")
-        resp = requests.get("https://test.atlassian.net/rest/api/2/issue/HELLO-123")
-        assert resp.status_code == 200
-        assert "HELLO-123" in fake_jira.issues
-
-        resp = requests.delete("https://test.atlassian.net/rest/api/2/issue/HELLO-123")
-        assert resp.status_code == 204
-
-        resp = requests.get("https://test.atlassian.net/rest/api/2/issue/HELLO-123")
-        assert resp.status_code == 404
-        assert "HELLO-123" not in fake_jira.issues
-
     def test_move_issue(self, fake_jira):
         issue1 = fake_jira.make_issue(project="HELLO", summary="This is a bad bug!")
         key1 = issue1.key
-        issue2 = fake_jira.move_issue(issue1, "BLENDED")
+        issue2 = fake_jira.move_issue(issue1, "GOODBYE")
         key2 = issue2.key
-        assert key2.startswith("BLENDED-")
+        assert key2.startswith("GOODBYE-")
 
         # Look it up under the old key.
         resp = requests.get(f"https://test.atlassian.net/rest/api/2/issue/{key1}")
@@ -86,10 +73,6 @@ class TestBadRequests:
     """
     def test_no_such_put(self, fake_jira):
         resp = requests.put("https://test.atlassian.net/rest/api/2/issue/XYZ-999")
-        assert resp.status_code == 404
-
-    def test_no_such_delete(self, fake_jira):
-        resp = requests.delete("https://test.atlassian.net/rest/api/2/issue/XYZ-999")
         assert resp.status_code == 404
 
     def test_no_such_transitions(self, fake_jira):

--- a/tests/test_pr_comments.py
+++ b/tests/test_pr_comments.py
@@ -16,21 +16,17 @@ from openedx_webhooks.bot_comments import (
 from .helpers import check_good_markdown
 
 
-def test_community_pr_comment(fake_github, fake_jira):
+def test_community_pr_comment(fake_github):
     # A pull request from a member in good standing.
     pr = fake_github.make_pull_request(user="tusbar")
-    jira = fake_jira.make_issue(key="TNL-12345")
-    comment = github_community_pr_comment(pr.as_json(), jira.key)
-    assert "[TNL-12345](https://test.atlassian.net/browse/TNL-12345)" in comment
+    comment = github_community_pr_comment(pr.as_json())
     assert not is_comment_kind(BotComment.NEED_CLA, comment)
     check_good_markdown(comment)
 
 
-def test_community_pr_comment_no_cla(fake_github, fake_jira):
+def test_community_pr_comment_no_cla(fake_github):
     pr = fake_github.make_pull_request(user="FakeUser")
-    jira = fake_jira.make_issue(key="FOO-1")
-    comment = github_community_pr_comment(pr.as_json(), jira.key)
-    assert "[FOO-1](https://test.atlassian.net/browse/FOO-1)" in comment
+    comment = github_community_pr_comment(pr.as_json())
     assert is_comment_kind(BotComment.NEED_CLA, comment)
     assert "[signed contributor agreement](https://openedx.org/cla)" in comment
     check_good_markdown(comment)


### PR DESCRIPTION
I tried to remove code that we wouldn't need in the future.  Some basic Jira operation code is still here, but not called.  There is probably more code that can be deleted, but this was a lot already.