### PR TITLE
feat: remove obsolete labels on pr close

### DIFF
--- a/openedx_webhooks/labels.py
+++ b/openedx_webhooks/labels.py
@@ -14,3 +14,24 @@ GITHUB_CATEGORY_LABELS = {
     "blended",
     "open-source-contribution",
 }
+
+GITHUB_MERGED_PR_OBSOLETE_LABELS = {
+    "blocked by other work",
+    "changes requested",
+    "inactive",
+    "needs maintainer attention",
+    "needs more product information",
+    "needs rescoping",
+    "needs reviewer assigned",
+    "needs test run",
+    "waiting for eng review",
+    "waiting on author",
+}
+
+GITHUB_CLOSED_PR_OBSOLETE_LABELS = {
+    "needs maintainer attention",
+    "needs reviewer assigned",
+    "needs test run",
+    "waiting for eng review",
+    "waiting on author",
+}

--- a/openedx_webhooks/tasks/pr_tracking.py
+++ b/openedx_webhooks/tasks/pr_tracking.py
@@ -70,6 +70,7 @@ from openedx_webhooks.tasks.jira_work import (
 )
 from openedx_webhooks.types import GhProject, JiraId, PrDict, PrId
 from openedx_webhooks.utils import (
+    get_pr_state,
     log_check_response,
     sentry_extra_context,
     text_summary,
@@ -227,15 +228,7 @@ def desired_support_state(pr: PrDict) -> PrDesiredInfo:
     else:
         desired.is_ospr = True
 
-    if pr.get("hook_action") == "reopened":
-        state = "reopened"
-    elif pr["state"] == "open":
-        state = "open"
-    elif pr["merged"]:
-        state = "merged"
-    else:
-        state = "closed"
-
+    state = get_pr_state(pr)
     # A label of jira:xyz means we want a Jira issue in the xyz Jira.
     desired.jira_nicks = {name.partition(":")[-1] for name in label_names if name.startswith("jira:")}
 
@@ -479,9 +472,10 @@ class PrTrackingFixer:
         """
         desired_labels = set(self.desired.github_labels)
         ad_hoc_labels = self.current.github_labels - GITHUB_CATEGORY_LABELS - GITHUB_STATUS_LABELS
-        if self.pr["state"] == "closed":
+        state = get_pr_state(self.pr)
+        if state == "closed":
             ad_hoc_labels -= GITHUB_CLOSED_PR_OBSOLETE_LABELS
-        elif self.pr["state"] == "merged":
+        elif state == "merged":
             ad_hoc_labels -= GITHUB_MERGED_PR_OBSOLETE_LABELS
         desired_labels.update(ad_hoc_labels)
 

--- a/openedx_webhooks/tasks/pr_tracking.py
+++ b/openedx_webhooks/tasks/pr_tracking.py
@@ -59,6 +59,8 @@ from openedx_webhooks.info import (
 )
 from openedx_webhooks.labels import (
     GITHUB_CATEGORY_LABELS,
+    GITHUB_CLOSED_PR_OBSOLETE_LABELS,
+    GITHUB_MERGED_PR_OBSOLETE_LABELS,
     GITHUB_STATUS_LABELS,
 )
 from openedx_webhooks import settings
@@ -477,6 +479,10 @@ class PrTrackingFixer:
         """
         desired_labels = set(self.desired.github_labels)
         ad_hoc_labels = self.current.github_labels - GITHUB_CATEGORY_LABELS - GITHUB_STATUS_LABELS
+        if self.pr["state"] == "closed":
+            ad_hoc_labels -= GITHUB_CLOSED_PR_OBSOLETE_LABELS
+        elif self.pr["state"] == "merged":
+            ad_hoc_labels -= GITHUB_MERGED_PR_OBSOLETE_LABELS
         desired_labels.update(ad_hoc_labels)
 
         if desired_labels != self.current.github_labels:

--- a/openedx_webhooks/utils.py
+++ b/openedx_webhooks/utils.py
@@ -19,7 +19,7 @@ from urlobject import URLObject
 
 from openedx_webhooks import logger
 from openedx_webhooks.auth import get_github_session, get_jira_session
-from openedx_webhooks.types import JiraDict
+from openedx_webhooks.types import JiraDict, PrDict
 
 
 def environ_get(name: str, default=None) -> str:
@@ -345,3 +345,18 @@ def jira_get(jira_nick, *args, **kwargs):
         if resp.content:
             return resp
     return get_jira_session(jira_nick).get(*args, **kwargs)
+
+
+def get_pr_state(pr: PrDict):
+    """
+    Get gthub pull request state.
+    """
+    if pr.get("hook_action") == "reopened":
+        state = "reopened"
+    elif pr["state"] == "open":
+        state = "open"
+    elif pr["merged"]:
+        state = "merged"
+    else:
+        state = "closed"
+    return state

--- a/tests/fake_github.py
+++ b/tests/fake_github.py
@@ -385,6 +385,7 @@ class FakeGitHub(faker.Faker):
         patch = request.json()
         if "labels" in patch:
             pr.set_labels(patch["labels"])
+        r.pull_requests[pr.number] = pr
         return pr.as_json()
 
     # Commmits

--- a/tests/test_pull_request_closed.py
+++ b/tests/test_pull_request_closed.py
@@ -122,3 +122,20 @@ def test_pr_closed_after_employee_leaves(org, is_merged, fake_github, mocker):
     assert pr.status(CLA_CONTEXT) == CLA_STATUS_GOOD
     assert pr.labels == set()
     assert pull_request_projects(pr.as_json()) == set()
+
+
+def test_pr_closed_labels(fake_github, is_merged):
+    """
+    Test whether obsolete labels are removed on closing merge requests
+    """
+    pr = fake_github.make_pull_request(
+        user="newuser",
+        owner="openedx",
+        repo="edx-platform",
+        body=None,
+    )
+    pr.set_labels({"open-source-contribution", "waiting on author", "needs test run", "custom label 1"})
+
+    pr.close(merge=is_merged)
+    pull_request_changed(pr.as_json())
+    assert pr.labels == {"open-source-contribution", "custom label 1"}


### PR DESCRIPTION
Removes obsolete labels from pull requests when it is merged or closed.

Related to: https://github.com/openedx/wg-coordination/issues/150

`Private-ref`: [FAL-4026](https://tasks.opencraft.com/browse/FAL-4026)

**Test instructions:**

* Set `GITHUB_PERSONAL_TOKEN=<your_token>` and `GITHUB_OSPR_PROJECT="openedx:19"` environment variables.
* Select a closed PR to test, you can use my [PR](https://github.com/openedx/openedx-webhooks/pull/327)
* Add some labels to PR like: `blocked by other work`, `needs reviewer assigned` etc.
* Get PR json using github cli, for example,
```sh
gh api \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/openedx/openedx-webhooks/pulls/327 > /tmp/some.json
```
* Update following lines in `openedx_webhooks/tasks/pr_tracking.py` to make the process faster.
```diff
Line 212 in `desired_support_state` function.
-    is_internal = is_internal_pull_request(pr)
+    is_internal = False
```

```diff
Line 268 in `desired_support_state` function.
-    has_signed_agreement = pull_request_has_cla(pr)
+    has_signed_agreement = True
```
* Add below snippet to `openedx_webhooks/tasks/github.py` file and execute it.
```python
if __name__ == '__main__':
    import json
    with open('/tmp/some.json') as f:
        pr = json.load(f)
    pull_request_changed(pr)
```
* This should remove the labels listed in `GITHUB_MERGED_PR_OBSOLETE_LABELS` and `GITHUB_CLOSED_PR_OBSOLETE_LABELS` variables.
