### PR TITLE
refactor: Change the formatting of the community PR message to make it tighter

### DIFF
--- a/openedx_webhooks/templates/github_community_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment.md.j2
@@ -8,7 +8,7 @@ This repository has no maintainer (yet).
 {% else %}
 This repository is currently unmaintained.
 {% endif %}
-<details><summary><h4>:radio_button: Find a technical reviewer</h4></summary>
+<details><summary>:radio_button: Find a technical reviewer</summary>
 To get help with finding a technical reviewer, reach out to the community contributions project manager for this PR:
 
 1. On the right-hand side of the PR, find the Contributions project, click the caret in the top right corner to expand it, and check the "Primary PM" field for the name of your project manager.
@@ -18,15 +18,16 @@ To get help with finding a technical reviewer, reach out to the community contri
 
 Once you've gone through the following steps feel free to tag them in a comment and let them know that your changes are ready for engineering review.
 
-<details><summary><h4>:radio_button: Get product approval</h4></summary>
+<details><summary>:radio_button: Get product approval</summary>
 
 If you haven't already, [check this list](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3875962884/How+to+submit+an+open+source+contribution+for+Product+Review#Does-my-contribution-require-Product-Review%3F) to see if your contribution needs to go through the product review process.
 
 - If it does, you'll need to submit a product proposal for your contribution, and have it reviewed by the [Product Working Group](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3449028609/Product+Working+Group).
     - This process (including the steps you'll need to take) is documented [here](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3875962884/How+to+submit+an+open+source+contribution+for+Product+Review#Product-Review-Process).
 - If it doesn't, simply proceed with the next step.
-</details><details>
-<summary><h4>:radio_button: Provide context</h4></summary>
+</details>
+
+<details><summary>:radio_button: Provide context</summary>
 
 To help your reviewers and other members of the community understand the purpose and larger context of your changes, feel free to add as much of the following information to the PR description as you can:
 
@@ -40,9 +41,10 @@ To help your reviewers and other members of the community understand the purpose
   > This is for a course on edx.org.
 - Supporting documentation
 - Relevant [Open edX discussion forum](https://discuss.openedx.org/) threads
-</details><details>
+</details>
+
 {% if not has_signed_agreement %}
-<summary><h4>:radio_button: Submit a signed contributor agreement (CLA)</h4></summary>
+<details><summary>:radio_button: Submit a signed contributor agreement (CLA)</summary>
 
 :warning: We ask all contributors to the Open edX project to submit a [signed contributor agreement](https://openedx.org/cla) or indicate their institutional affiliation.
 Please see the [CONTRIBUTING](https://github.com/openedx/.github/blob/master/CONTRIBUTING.md) file for more information.
@@ -53,43 +55,44 @@ See [The New Home of the Open edX Codebase](https://open.edx.org/blog/the-new-ho
 Once you've signed the CLA, please allow 1 business day for it to be processed.
 After this time, you can re-run the CLA check by adding a comment below that you have signed it.
 If the CLA check continues to fail, you can tag the `@openedx/cla-problems` team in a comment for further assistance.
-</details><details>
+</details>
 <!-- comment:no_cla -->
 {% endif %}
 
 {% if is_first_time %}
-<summary><h4>:radio_button: Wait for tests to be enabled</h4></summary>
+<details><summary>:radio_button: Wait for tests to be enabled</summary>
 
 It looks like you are contributing to this repository for the first time.
 This means that automated tests won't run automatically, and that you'll need to wait for a test run to be authorized.
 
 If you're experiencing a delay of two weeks or more at this step, tag the [community contributions project managers](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3548807177/Community+Contributions+Project+Manager#Current-OSPR-Project-Managers) in a comment and ask for help.
-</details><details>
+</details>
 {% endif %}
 
-<summary><h4>:radio_button: Get a green build</h4></summary>
+<details><summary>:radio_button: Get a green build</summary>
 
 If one or more checks are failing, continue working on your changes until this is no longer the case and your build turns green.
 </details><details>
 {% if is_draft %}
-<summary><h4>:radio_button: Update the status of your PR</h4></summary>
+<summary>:radio_button: Update the status of your PR</summary>
 
 Your PR is currently marked as a draft.  After completing the steps above, update its status by clicking "Ready for Review", or removing "WIP" from the title, as appropriate.
-</details><details>
+</details>
 <!-- comment:end_of_wip -->
 {% endif %}
 
 ---
 
-<summary><h3>Where can I find more information? </h3></summary>
+<details><summary>Where can I find more information?</summary>
 
 If you'd like to get more details on all aspects of the review process for open source pull requests (OSPRs), check out the following resources:
 
 - [Overview of Review Process for Community Contributions](https://docs.openedx.org/en/latest/developers/references/developer_guide/process/FAQ-about-pull-requests.html)
 - [Pull Request Status Guide](https://docs.openedx.org/en/latest/developers/references/developer_guide/process/pull-request-statuses.html)
 - [Making changes to your pull request](https://docs.openedx.org/en/latest/documentors/how-tos/make_changes_to_your_pull_request.html)
-</details><details>
-<summary><h3>When can I expect my changes to be merged?</h3></summary>
+</details>
+
+<details><summary>When can I expect my changes to be merged?</summary>
 
 Our goal is to get community contributions seen and reviewed as efficiently as possible.
 


### PR DESCRIPTION
The current message is too spaced out, this change fixes the spacing issues and moves the hr to the correct place.

The h3 and h4 have been removed since they add too much spacing around in the collapsable and make the message seem too spaced out. Being inside a collapsable section already highlights them quite a bit so I'm hoping this is okay. 


Screenshot after update:
![Screen Shot 2025-01-23 at 11 12 55](https://github.com/user-attachments/assets/85bede85-2bdb-4803-aad9-7e5b45418cdc)
