### PR TITLE
fix: Don't mention the owner directly in the welcome message.

### DIFF
--- a/openedx_webhooks/templates/github_community_pr_comment.md.j2
+++ b/openedx_webhooks/templates/github_community_pr_comment.md.j2
@@ -1,7 +1,7 @@
 Thanks for the pull request, @{{ user }}!
 
 {% if owner %}
-This repository is currently maintained by @{{ owner }}.
+This repository is currently maintained by `@{{ owner }}`.
 {% else %}
 {% if lifecycle == 'production' %}
 This repository has no maintainer (yet).

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -95,7 +95,7 @@ def test_pr_with_owner_repo_opened(get_catalog_info, fake_github, owner, tag, mo
     pr_comments = pr.list_comments()
     assert len(pr_comments) == 1
     body = pr_comments[0].body
-    assert f"This repository is currently maintained by {tag}" in body
+    assert f"This repository is currently maintained by `{tag}`" in body
 
 
 @pytest.mark.parametrize("lifecycle", ["production", "deprecated", None])


### PR DESCRIPTION
We had backticks before and we removed them when we re-worded this.
However, we should put them back in.  Currently the maintainers get
mentioned and there fore start recieving notifications on all PRs
whether or not they are ready for their review.  This is causing a bit
of churn and waste as people have to check more PRs than necessary
especially since many PRs have known reviewers from the same team or via
FCs.
