### PR TITLE
feat: automatically fill closed or merged date in project

### DIFF
--- a/openedx_webhooks/types.py
+++ b/openedx_webhooks/types.py
@@ -17,6 +17,9 @@ JiraDict = Dict
 # A GitHub project: org name, and number.
 GhProject = Tuple[str, int]
 
+# A GitHub project info: org name, number and pr node id in project.
+PrGhProject = Dict
+
 # A GitHub project metadata json object.
 GhPrMetaDict = Dict
 

--- a/tests/fake_github.py
+++ b/tests/fake_github.py
@@ -113,6 +113,7 @@ class PullRequest:
     node_id: str = field(default_factory=fake_node_id)
     created_at: datetime.datetime = field(default_factory=patchable_now)
     closed_at: Optional[datetime.datetime] = None
+    merged_at: Optional[datetime.datetime] = None
     comments: List[int] = field(default_factory=list)
     labels: Set[str] = field(default_factory=set)
     state: str = "open"
@@ -140,6 +141,7 @@ class PullRequest:
             },
             "created_at": self.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "closed_at": self.closed_at.strftime("%Y-%m-%dT%H:%M:%SZ") if self.closed_at else None,
+            "merged_at": self.merged_at.strftime("%Y-%m-%dT%H:%M:%SZ") if self.merged_at else None,
             "url": f"{self.repo.github.host}/repos/{self.repo.full_name}/pulls/{self.number}",
             "html_url": f"https://github.com/{self.repo.full_name}/pull/{self.number}",
         }
@@ -154,6 +156,7 @@ class PullRequest:
         self.state = "closed"
         self.merged = merge
         self.closed_at = datetime.datetime.now()
+        self.merged_at = datetime.datetime.now()
 
     def reopen(self):
         """
@@ -162,6 +165,7 @@ class PullRequest:
         self.state = "open"
         self.merged = False
         self.closed_at = None
+        self.merged_at = None
 
     def add_comment(self, user="someone", **kwargs) -> Comment:
         comment = self.repo.make_comment(user, **kwargs)
@@ -461,7 +465,7 @@ class FakeGitHub(faker.Faker):
         for node_id in project_node_ids:
             org, num = self.project_nodes[node_id]
             nodes.append(
-                {"project": {"owner": {"login": org}, "number": num}}
+                {"project": {"owner": {"login": org}, "number": num}, "id": node_id}
             )
         return {
             "data": {
@@ -518,6 +522,7 @@ class FakeGitHub(faker.Faker):
                             "nodes": [
                                 {"name": "Name", "id": "name-id", "dataType": "text"},
                                 {"name": "Date opened", "id": "date-opened-id", "dataType": "date"},
+                                {"name": "Date merged/closed", "id": "date-closed-id", "dataType": "date"},
                                 {"name": "Repo Owner / Owning Team", "id": "repo-owner-id", "dataType": "text"},
                             ]
                         }

--- a/tests/test_gh_projects.py
+++ b/tests/test_gh_projects.py
@@ -3,6 +3,7 @@
 from openedx_webhooks.gh_projects import (
     add_pull_request_to_project,
     pull_request_projects,
+    pull_request_projects_info,
 )
 from openedx_webhooks.types import PrId
 
@@ -16,7 +17,9 @@ def test_adding_pr_to_project(fake_github):
     assert not pr.is_in_project(("myorg", 23))
 
     add_pull_request_to_project(prid, pr.node_id, ("myorg", 23))
-    projects = set(pull_request_projects(prj))
+    project_info = pull_request_projects_info(prj)
+    assert project_info == [{'id': 'PROJECT:myorg.23', 'org': 'myorg', 'number': 23}]
+    projects = set(pull_request_projects(prj, project_info))
     assert projects == {("myorg", 23)}
     assert pr.is_in_project(("myorg", 23))
     assert not pr.is_in_project(("anotherorg", 27))

--- a/tests/test_pull_request_closed.py
+++ b/tests/test_pull_request_closed.py
@@ -2,16 +2,13 @@
 
 import pytest
 
-from openedx_webhooks.bot_comments import (
-    BotComment,
-)
 from openedx_webhooks.cla_check import (
     CLA_CONTEXT,
     CLA_STATUS_GOOD,
-    CLA_STATUS_NO_CONTRIBUTIONS,
 )
 from openedx_webhooks.gh_projects import pull_request_projects
 from openedx_webhooks.tasks.github import pull_request_changed
+
 from .helpers import check_issue_link_in_markdown, random_text
 
 # These tests should run when we want to test flaky GitHub behavior.
@@ -139,3 +136,11 @@ def test_pr_closed_labels(fake_github, is_merged):
     pr.close(merge=is_merged)
     pull_request_changed(pr.as_json())
     assert pr.labels == {"open-source-contribution", "custom label 1"}
+
+
+def test_pr_closed_date_on_close(closed_pull_request):
+    pr = closed_pull_request
+    pull_request_changed(pr.as_json())
+    assert pr.repo.github.project_items['date-closed-id'] == {
+        pr.closed_at.isoformat(timespec='seconds') + 'Z',
+    }

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -499,6 +499,7 @@ def test_pr_project_fields_data(fake_github, mocker, owner):
     pr = fake_github.make_pull_request(owner="openedx", repo="edx-platform", created_at=created_at)
     pull_request_changed(pr.as_json())
     assert pr.repo.github.project_items['date-opened-id'] == {created_at.isoformat() + 'Z'}
+    assert pr.repo.github.project_items['date-closed-id'] == set()
     owner_type, owner_name = owner.split(":")
     if owner_type == "user":
         assert pr.repo.github.project_items['repo-owner-id'] == {f"{owner_name.title()} (@{owner_name})"}

--- a/tests/test_rescan.py
+++ b/tests/test_rescan.py
@@ -111,6 +111,7 @@ def test_rescan_repository_dry_run(rescannable_repo, fake_github, fake_jira, pul
             "update_labels_on_pull_request",    # ["open-source-contribution"]
             "add_comment_to_pull_request",      # "Thanks for the pull request, @tusbar!"
             "add_pull_request_to_project",
+            "update_project_pr_custom_field",
         ],
         106: [
             "initial_state",
@@ -118,9 +119,11 @@ def test_rescan_repository_dry_run(rescannable_repo, fake_github, fake_jira, pul
             "update_labels_on_pull_request",    # ["open-source-contribution"]
             "add_comment_to_pull_request",      # "Thanks for the pull request, @tusbar!"
             "add_pull_request_to_project",
+            "update_project_pr_custom_field",
         ],
         108: [
             "initial_state",
+            "update_project_pr_custom_field",
         ],
         110: [
             "initial_state",


### PR DESCRIPTION

Automatically adds closed/merged date to project item for a PR on close/merge.

## Test instructions

* Set `GITHUB_PERSONAL_TOKEN=<your_token>` and `GITHUB_OSPR_PROJECT="openedx:19"` environment variables.
* Select a closed PR to test and make sure it has no value in `Date merged/closed` field in OSPR project board, you can use my [PR](https://github.com/openedx/edx-platform/pull/35899)
* Get PR json using github cli, for example,
```sh
gh api \
-H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
/repos/openedx/edx-platform/pulls/35899 > /tmp/some.json
```
* Update following lines in `openedx_webhooks/tasks/pr_tracking.py` to make the process faster.
```diff
Line 217 in `desired_support_state` function.
-    is_internal = is_internal_pull_request(pr)
+    is_internal = False
```

```diff
Line 273 in `desired_support_state` function.
-    has_signed_agreement = pull_request_has_cla(pr)
+    has_signed_agreement = True
```
* Add below snippet to `openedx_webhooks/tasks/pr_tracking.py` file and execute it.
```python
if __name__ == '__main__':
    import json
    with open('/tmp/some.json') as f:
        pr = json.load(f)
    fixer = PrTrackingFixer(pr, current_support_state(pr), desired_support_state(pr))
    fixer._fix_project_node_fields()
```
* Verify that the `Date merged/closed` field info for the PR was added to OSPR board.
