### PR TITLE
fix: Treat github usernames in a case-insensitively

### DIFF
--- a/openedx_webhooks/info.py
+++ b/openedx_webhooks/info.py
@@ -118,7 +118,7 @@ def get_people_file():
         first_name = row['First Name']
         last_name = row['Last Name']
         acct_name = row['Account Name']
-        github_username = row['GitHub Username']
+        github_username = row['GitHub Username'].lower()
 
         people[github_username] = {
             "name": f"{first_name} {last_name}"
@@ -240,7 +240,7 @@ def _pr_author_data(pull_request: PrDict) -> Optional[Dict]:
     Returns None if the author had no CLA.
     """
     people = get_people_file()
-    author = pull_request["user"]["login"]
+    author = pull_request["user"]["login"].lower()
     return people.get(author)
 
 

--- a/tests/repo_data/openedx/openedx-webhooks-data/salesforce-export.csv
+++ b/tests/repo_data/openedx/openedx-webhooks-data/salesforce-export.csv
@@ -1,6 +1,6 @@
 "First Name","Last Name","Number of Active Ind. CLA Contracts","Title","Account Name","Number of Active Entity CLA Contracts","GitHub Username","Is Core Contributor"
 "Xavier","Antoviaque","","","OpenCraft","","antoviaque","1"
-"Feanil","Patel","","","tCRIL","","feanil","1"
+"Feanil","Patel","","","tCRIL","","FeAnIl","1"
 "Felipe","Montoya","","","EduNEXT","","felipemontoya","1"
 "Holly","Hunter","","","Individual Contributors","","hollyhunter","0"
 "John","Jarvis","","","Individual Contributors","","jarv","0"


### PR DESCRIPTION
Github treats them in a case insensitive manner but users can still
choose the casing of their name.  Our code for looking up users
previously was case-sensitive which was causing failures when someone
changed the casing in their github username.

This change updates the code so that the name we get associated with a
PR and the name we look up in the salesforce exports are both lowercased
before we do any comparisons.
