### PR TITLE
fix: Don't remove "core contributor" label if manually added.

### DIFF
--- a/openedx_webhooks/labels.py
+++ b/openedx_webhooks/labels.py
@@ -13,7 +13,6 @@ GITHUB_STATUS_LABELS: set[str] = set()
 GITHUB_CATEGORY_LABELS = {
     "blended",
     "open-source-contribution",
-    "core contributor",
 }
 
 GITHUB_MERGED_PR_OBSOLETE_LABELS = {

--- a/tests/test_pull_request_opened.py
+++ b/tests/test_pull_request_opened.py
@@ -346,14 +346,26 @@ def test_add_to_multiple_projects(fake_github):
     ("pdpinch", True),  # CC
     ("jarv", False),    # Not CC
 ])
-def test_core_contributor_label(fake_github, username, cc_label):
+def test_automatic_core_contributor_label(fake_github, username, cc_label):
     pr = fake_github.make_pull_request(owner="openedx", repo="some-code", user=username, title="fix: XYZ")
     prj = pr.as_json()
-    result = pull_request_changed(prj)
+    pull_request_changed(prj)
     if cc_label:
         assert "core contributor" in pr.labels
     else:
         assert "core contributor" not in pr.labels
+
+@pytest.mark.parametrize("username", [
+    "feanil",   # CC but not OSPR
+    "pdpinch",  # CC
+    "jarv",     # Not CC
+])
+def test_manual_core_contributor_label(fake_github, username):
+    pr = fake_github.make_pull_request(owner="openedx", repo="some-code", user=username, title="fix: XYZ")
+    pr.set_labels(["core contributor"])
+    prj = pr.as_json()
+    pull_request_changed(prj)
+    assert "core contributor" in pr.labels
 
 def test_crash_label(fake_github):
     pr = fake_github.make_pull_request("openedx", user="nedbat")


### PR DESCRIPTION
The previous implementation entirely automated the addition and removal of the "core contributor" label. Unfortunately this meant that adding the label manually to a PR didn't work since the webhook would run and remove the label if it didn't have the information to know that it would apply.

Fixes: https://github.com/openedx/wg-coordination/issues/159