### PR TITLE
fix: Handle the case where catalog-info.yaml is malformed.

### DIFF
--- a/openedx_webhooks/info.py
+++ b/openedx_webhooks/info.py
@@ -317,7 +317,12 @@ def get_bot_comments(prid: PrId) -> Iterable[PrCommentDict]:
 def get_catalog_info(repo_fullname: str) -> Dict:
     """Get the parsed catalog-info.yaml data from a repo, or {} if missing."""
     yml = read_github_file(repo_fullname, "catalog-info.yaml", not_there="{}")
-    return yaml.safe_load(yml)
+    try:
+        data = yaml.safe_load(yml)
+    except yaml.YAMLError:
+        logging.warning(f"Failed to parse catalog-info.yaml file in {repo_fullname}.")
+        return {}
+    return data
 
 
 @memoize_timed(minutes=60)

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -11,6 +11,7 @@ from openedx_webhooks.info import (
     is_draft_pull_request,
     is_internal_pull_request,
     jira_details_for_pr,
+    get_catalog_info,
 )
 
 
@@ -163,3 +164,25 @@ def test_jira_details_for_pr(fake_github, owner, repo, project, issuetype):
     actual_project, actual_issuetype = jira_details_for_pr("test1", pr.as_json())
     assert project == actual_project
     assert issuetype == actual_issuetype
+
+
+def test_get_malformed_catalog_info(mocker, caplog):
+    mocker.patch(
+        "openedx_webhooks.info.read_github_file",
+        lambda *args,**kwargs: "bad: 'yaml"
+    )
+    info = get_catalog_info("foo")
+    assert info == {}
+    assert "Failed to parse catalog-info.yaml file in foo." in caplog.text
+
+def test_get_valid_catalog_info(mocker):
+    mocker.patch(
+        "openedx_webhooks.info.read_github_file",
+        lambda *args,**kwargs: "good: 'yaml'"
+    )
+    info = get_catalog_info("foo")
+    assert info == {"good": "yaml"}
+
+
+
+


### PR DESCRIPTION
Currently if the catalog-info.yaml file is malformed an uncaught
exception is thrown and we stop updating the CLA data on PRs to that
repo.  Treat bad catalog-info.yaml data the same as if the file is
missing.
